### PR TITLE
docs: fix invalid path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ html_logo = 'image/logo.png'
 html_title = ' '
 html_copy_source = False
 html_context = {
-    'conf_py_path': '/docs/',
+    'conf_py_path': '/docs/source/',
     'display_github': False,
     'github_user': 'PKU-Alignment',
     'github_repo': 'OmniSafe',


### PR DESCRIPTION
# Description

All the `Edit this page` icon in the documentation are invalid.
![Edit this page](https://github.com/PKU-Alignment/omnisafe/assets/80799351/cf5a9adc-2e9c-43eb-828f-0cded05d97fa)

![Snipaste_2023-06-11_17-00-06](https://github.com/PKU-Alignment/omnisafe/assets/80799351/23e90e87-8824-4790-b29c-c8b498bd8e48)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
