### PR TITLE
chore(off-policy): clear redundant distributed grad average

### DIFF
--- a/omnisafe/algorithms/algo_wrapper.py
+++ b/omnisafe/algorithms/algo_wrapper.py
@@ -88,13 +88,15 @@ class AlgoWrapper:
             self.algo in ALGORITHMS['all']
         ), f"{self.algo} doesn't exist. Please choose from {ALGORITHMS['all']}."
         self.algo_type = ALGORITHM2TYPE.get(self.algo, '')
-        if self.algo_type in ['model-based', 'offline'] and self.train_terminal_cfgs is not None:
-            assert (
-                self.train_terminal_cfgs['parallel'] == 1
-            ), 'model-based and offline only support parallel==1!'
-            assert (
-                self.train_terminal_cfgs['vector_env_nums'] == 1
-            ), 'model-based and offline only support vector_env_nums==1!'
+        if self.train_terminal_cfgs is not None:
+            if self.algo_type in ['model-based', 'offline']:
+                assert (
+                    self.train_terminal_cfgs['vector_env_nums'] == 1
+                ), 'model-based and offline only support vector_env_nums==1!'
+            if self.algo_type in ['off-policy', 'model-based', 'offline']:
+                assert (
+                    self.train_terminal_cfgs['parallel'] == 1
+                ), 'off-policy, model-based and offline only support parallel==1!'
 
         cfgs = get_default_kwargs_yaml(self.algo, self.env_id, self.algo_type)
 

--- a/omnisafe/algorithms/off_policy/sac.py
+++ b/omnisafe/algorithms/off_policy/sac.py
@@ -21,7 +21,6 @@ from torch.nn.utils.clip_grad import clip_grad_norm_
 from omnisafe.algorithms import registry
 from omnisafe.algorithms.off_policy.ddpg import DDPG
 from omnisafe.models.actor_critic.constraint_actor_q_critic import ConstraintActorQCritic
-from omnisafe.utils import distributed
 
 
 @registry.register
@@ -142,7 +141,6 @@ class SAC(DDPG):
                 self._actor_critic.reward_critic.parameters(),
                 self._cfgs.algo_cfgs.max_grad_norm,
             )
-        distributed.avg_grads(self._actor_critic.reward_critic)
         self._actor_critic.reward_critic_optimizer.step()
         self._logger.store(
             {

--- a/omnisafe/algorithms/off_policy/td3.py
+++ b/omnisafe/algorithms/off_policy/td3.py
@@ -21,7 +21,6 @@ from torch.nn.utils.clip_grad import clip_grad_norm_
 from omnisafe.algorithms import registry
 from omnisafe.algorithms.off_policy.ddpg import DDPG
 from omnisafe.models.actor_critic.constraint_actor_q_critic import ConstraintActorQCritic
-from omnisafe.utils import distributed
 
 
 @registry.register
@@ -108,7 +107,6 @@ class TD3(DDPG):
                 self._actor_critic.reward_critic.parameters(),
                 self._cfgs.algo_cfgs.max_grad_norm,
             )
-        distributed.avg_grads(self._actor_critic.reward_critic)
         self._actor_critic.reward_critic_optimizer.step()
         self._logger.store(
             {


### PR DESCRIPTION
# Description

Remove redundant distributed average gradient in off-policy algorithms

## Motivation and Context

Resolve issue #252 

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
