### PR TITLE
feat: rebase CRPO from PPO to TRPO

### DIFF
--- a/omnisafe/algorithms/on_policy/primal/crpo.py
+++ b/omnisafe/algorithms/on_policy/primal/crpo.py
@@ -75,6 +75,6 @@ class OnCRPO(TRPO):
             {
                 'Misc/RewUpdate': self._rew_update,
                 'Misc/CostUpdate': self._cost_update,
-            }
+            },
         )
         return -adv_c

--- a/omnisafe/algorithms/on_policy/primal/crpo.py
+++ b/omnisafe/algorithms/on_policy/primal/crpo.py
@@ -17,12 +17,12 @@
 import torch
 
 from omnisafe.algorithms import registry
-from omnisafe.algorithms.on_policy.base.ppo import PPO
+from omnisafe.algorithms.on_policy.base.trpo import TRPO
 from omnisafe.utils.config import Config
 
 
 @registry.register
-class OnCRPO(PPO):
+class OnCRPO(TRPO):
     """The on-policy CRPO algorithm.
 
     References:
@@ -71,4 +71,10 @@ class OnCRPO(PPO):
             self._rew_update += 1
             return adv_r
         self._cost_update += 1
+        self._logger.store(
+            {
+                'Misc/RewUpdate': self._rew_update,
+                'Misc/CostUpdate': self._cost_update,
+            }
+        )
         return -adv_c

--- a/omnisafe/configs/on-policy/OnCRPO.yaml
+++ b/omnisafe/configs/on-policy/OnCRPO.yaml
@@ -128,13 +128,3 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
-  # lagrangian configurations
-  lagrange_cfgs:
-    # Tolerance of constraint violation
-    cost_limit: 25.0
-    # Initial value of lagrangian multiplier
-    lagrangian_multiplier_init: 0.001
-    # Learning rate of lagrangian multiplier
-    lambda_lr: 0.035
-    # Type of lagrangian optimizer
-    lambda_optimizer: "Adam"

--- a/omnisafe/configs/on-policy/OnCRPO.yaml
+++ b/omnisafe/configs/on-policy/OnCRPO.yaml
@@ -33,21 +33,21 @@ defaults:
     # number of steps to update the policy
     steps_per_epoch: 20000
     # number of iterations to update the policy
-    update_iters: 40
+    update_iters: 10
     # batch size for each iteration
-    batch_size: 64
+    batch_size: 128
     # target kl divergence
-    target_kl: 0.02
+    target_kl: 0.01
     # entropy coefficient
     entropy_coef: 0.0
     # normalize reward
-    reward_normalize: True
+    reward_normalize: False
     # normalize cost
-    cost_normalize: True
+    cost_normalize: False
     # normalize observation
     obs_normalize: True
     # early stop when kl divergence is bigger than target kl
-    kl_early_stop: True
+    kl_early_stop: False
     # use max gradient norm
     use_max_grad_norm: True
     # max gradient norm
@@ -64,8 +64,6 @@ defaults:
     lam: 0.95
     # lambda for cost gae
     lam_c: 0.95
-    # clip ratio
-    clip: 0.2
     # advantage estimation method, options: gae, retrace
     adv_estimation_method: gae
     # standardize reward advantage
@@ -75,7 +73,15 @@ defaults:
     # penalty coefficient
     penalty_coef: 0.0
     # use cost
-    use_cost: False
+    use_cost: True
+    # Damping value for conjugate gradient
+    cg_damping: 0.1
+    # Number of conjugate gradient iterations
+    cg_iters: 15
+    # Subsampled observation
+    fvp_obs: None
+    # The sub-sampling rate of the observation
+    fvp_sample_freq: 1
     # the cost limit
     cost_limit: 25.0
     # the tolerance of cost limit
@@ -101,7 +107,7 @@ defaults:
     # actor type, options: gaussian, gaussian_learning
     actor_type: gaussian_learning
     # linear learning rate decay
-    linear_lr_decay: True
+    linear_lr_decay: False
     # exploration noise anneal
     exploration_noise_anneal: False
     # std upper bound, and lower bound
@@ -114,11 +120,21 @@ defaults:
       activation: tanh
       # out_activation: tanh
       # learning rate
-      lr: 0.0003
+      lr: ~
     critic:
       # hidden layer sizes
       hidden_sizes: [64, 64]
       # activation function
       activation: tanh
       # learning rate
-      lr: 0.0003
+      lr: 0.001
+  # lagrangian configurations
+  lagrange_cfgs:
+    # Tolerance of constraint violation
+    cost_limit: 25.0
+    # Initial value of lagrangian multiplier
+    lagrangian_multiplier_init: 0.001
+    # Learning rate of lagrangian multiplier
+    lambda_lr: 0.035
+    # Type of lagrangian optimizer
+    lambda_optimizer: "Adam"


### PR DESCRIPTION
# Description

The original implementation of CRPO uses TRPO as the base algorithm.
We rebase the on-policy version of CRPO, that is, `OnCRPO`, from PPO to TRPO, and tune the config file.
We evaluate the new implementation in the following environment in [SafetyGymnasium](https://github.com/PKU-Alignment/safety-gymnasium):
**SafetyCarGoal1-v0**
![SafetyCarGoal1-v0---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/4f6b1040-f00a-41f2-8abc-35a01730bf06)

**SafetyPointGoal1-v0**
![SafetyPointGoal1-v0---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/228f0b5c-e000-44bb-9d8d-d3eea676be9e)

**SafetyAntVelocity-v1**
![SafetyAntVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/41ef9d4f-923c-4f53-8893-60ab4c5f5139)

**SafetyHalfCheetahVelocity-v1**
![SafetyHalfCheetahVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/773a0922-c3e1-4bc9-9d0a-4b77c9273ab1)

**SafetyHopperVelocity-v1**
![SafetyHopperVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/0a2a1c16-7439-4b8e-a97f-a5f6d9d2a8b7)

**SafetyHumanoidVelocity-v1**
![SafetyHumanoidVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/edc926f8-f43d-468a-9605-ccaa7c77e605)

**SafetyWalker2dVelocity-v1**
![SafetyWalker2dVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/fa5e3744-32e7-4b95-a54d-5cf105deb3d5)

**SafetySwimmerVelocity-v1**
![SafetySwimmerVelocity-v1---OnCRPO](https://github.com/PKU-Alignment/omnisafe/assets/108712610/d2c17a07-dd3e-43fb-aca2-86104a1ba4d9)

## Motivation and Context

The performance of CRPO can not reach our expectation and it is different from original implementation.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
