### PR TITLE
feat(off-policy): fix final_obsevation setting and support evaluation times configuation

### DIFF
--- a/omnisafe/adapter/offpolicy_adapter.py
+++ b/omnisafe/adapter/offpolicy_adapter.py
@@ -137,7 +137,8 @@ class OffPolicyAdapter(OnlineAdapter):
             real_next_obs = next_obs.clone()
             for idx, done in enumerate(torch.logical_or(terminated, truncated)):
                 if done:
-                    real_next_obs[idx] = info['final_observation'][idx]
+                    if 'final_observation' in info:
+                        real_next_obs[idx] = info['final_observation'][idx]
                     self._log_metrics(logger, idx)
                     self._reset_log(idx)
 

--- a/omnisafe/adapter/online_adapter.py
+++ b/omnisafe/adapter/online_adapter.py
@@ -72,7 +72,6 @@ class OnlineAdapter:
         )
 
         self._env.set_seed(seed)
-        self._eval_env.set_seed(seed)
 
     def _wrapper(
         self,

--- a/omnisafe/algorithms/off_policy/ddpg.py
+++ b/omnisafe/algorithms/off_policy/ddpg.py
@@ -200,9 +200,10 @@ class DDPG(BaseAlgo):
         self._logger.register_key('Metrics/EpCost', window_length=50)
         self._logger.register_key('Metrics/EpLen', window_length=50)
 
-        self._logger.register_key('Metrics/TestEpRet', window_length=50)
-        self._logger.register_key('Metrics/TestEpCost', window_length=50)
-        self._logger.register_key('Metrics/TestEpLen', window_length=50)
+        if self._cfgs.train_cfgs.eval_episodes > 0:
+            self._logger.register_key('Metrics/TestEpRet', window_length=50)
+            self._logger.register_key('Metrics/TestEpCost', window_length=50)
+            self._logger.register_key('Metrics/TestEpLen', window_length=50)
 
         self._logger.register_key('Train/Epoch')
         self._logger.register_key('Train/LR')
@@ -283,7 +284,7 @@ class DDPG(BaseAlgo):
 
             eval_start = time.time()
             self._env.eval_policy(
-                episode=1,
+                episode=self._cfgs.train_cfgs.eval_episodes,
                 agent=self._actor_critic,
                 logger=self._logger,
             )

--- a/omnisafe/configs/off-policy/DDPG.yaml
+++ b/omnisafe/configs/off-policy/DDPG.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/DDPGLag.yaml
+++ b/omnisafe/configs/off-policy/DDPGLag.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/DDPGPID.yaml
+++ b/omnisafe/configs/off-policy/DDPGPID.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/SAC.yaml
+++ b/omnisafe/configs/off-policy/SAC.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/SACLag.yaml
+++ b/omnisafe/configs/off-policy/SACLag.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/SACPID.yaml
+++ b/omnisafe/configs/off-policy/SACPID.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/TD3.yaml
+++ b/omnisafe/configs/off-policy/TD3.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/TD3Lag.yaml
+++ b/omnisafe/configs/off-policy/TD3Lag.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy

--- a/omnisafe/configs/off-policy/TD3PID.yaml
+++ b/omnisafe/configs/off-policy/TD3PID.yaml
@@ -28,6 +28,8 @@ defaults:
     parallel: 1
     # total number of steps to train
     total_steps: 1000000
+    # number of evaluate episodes
+    eval_episodes: 1
   # algorithm configurations
   algo_cfgs:
     # number of steps to update the policy


### PR DESCRIPTION
# Description

- [feat: support evaluation episodes configuration](https://github.com/PKU-Alignment/omnisafe/commit/a90dbfd164ffc7c6285a6506c84924f5d65a83e4)
- [fix: fix final observation setting in off-policy algorithms](https://github.com/PKU-Alignment/omnisafe/commit/30d90f86f6a8b666ea5757740dbfab14e92488e1)

## Motivation and Context

- Previously the off-policy algorithms must evaluate once per episode, This pull request would set the times of evaluation as a configuration. If you do not want to evaluate during training process, please set it to 0.
- We process the ``final_observation`` to address the issue of the end of trajectory. However, not all environments have the key ``final_observation`` in the ``info`` of ``step`` function. So we fix it by a simple ``if-else`` judgement.

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
