### PR TITLE
feat: support gymnasium style reset API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: debug-statements
       - id: double-quote-string-fixer
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.282
+    rev: v0.0.284
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/omnisafe/adapter/offline_adapter.py
+++ b/omnisafe/adapter/offline_adapter.py
@@ -95,14 +95,18 @@ class OfflineAdapter:
         """
         return self._env.step(actions)
 
-    def reset(self) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        return self._env.reset()
+        return self._env.reset(seed=seed, options=options)
 
     def evaluate(
         self,

--- a/omnisafe/adapter/offline_adapter.py
+++ b/omnisafe/adapter/offline_adapter.py
@@ -102,6 +102,10 @@ class OfflineAdapter:
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
+        Args:
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.

--- a/omnisafe/adapter/online_adapter.py
+++ b/omnisafe/adapter/online_adapter.py
@@ -170,6 +170,10 @@ class OnlineAdapter:
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
+        Args:
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.

--- a/omnisafe/adapter/online_adapter.py
+++ b/omnisafe/adapter/online_adapter.py
@@ -163,14 +163,18 @@ class OnlineAdapter:
         """
         return self._env.step(action)
 
-    def reset(self) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        return self._env.reset()
+        return self._env.reset(seed=seed, options=options)
 
     def save(self) -> dict[str, torch.nn.Module]:
         """Save the important components of the environment.

--- a/omnisafe/adapter/saute_adapter.py
+++ b/omnisafe/adapter/saute_adapter.py
@@ -119,6 +119,10 @@ class SauteAdapter(OnPolicyAdapter):
         .. note::
             Additionally, the safety observation will be reset.
 
+        Args:
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.

--- a/omnisafe/adapter/saute_adapter.py
+++ b/omnisafe/adapter/saute_adapter.py
@@ -109,7 +109,11 @@ class SauteAdapter(OnPolicyAdapter):
         if self._env.num_envs == 1:
             self._env = Unsqueeze(self._env, device=self._device)
 
-    def reset(self) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         .. note::
@@ -119,7 +123,7 @@ class SauteAdapter(OnPolicyAdapter):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        obs, info = self._env.reset()
+        obs, info = self._env.reset(seed=seed, options=options)
         self._safety_obs = torch.ones(self._env.num_envs, 1).to(self._device)
         obs = self._augment_obs(obs)
         return obs, info

--- a/omnisafe/adapter/simmer_adapter.py
+++ b/omnisafe/adapter/simmer_adapter.py
@@ -99,6 +99,10 @@ class SimmerAdapter(SauteAdapter):
             Additionally, the safety observation will be reset. And the safety budget will be reset
             to the value of current ``rel_safety_budget``.
 
+        Args:
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
         Returns:
             observation: The initial observation of the space.
             info: Some information logged by the environment.

--- a/omnisafe/adapter/simmer_adapter.py
+++ b/omnisafe/adapter/simmer_adapter.py
@@ -88,7 +88,11 @@ class SimmerAdapter(SauteAdapter):
             budget_bound=self._upper_budget.cpu(),
         )
 
-    def reset(self) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         .. note::
@@ -99,7 +103,7 @@ class SimmerAdapter(SauteAdapter):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        obs, info = self._env.reset()
+        obs, info = self._env.reset(seed=seed, options=options)
         self._safety_obs = self._rel_safety_budget * torch.ones(self._num_envs, 1).to(self._device)
         obs = self._augment_obs(obs)
         return obs, info

--- a/omnisafe/algorithms/model_based/planner/arc.py
+++ b/omnisafe/algorithms/model_based/planner/arc.py
@@ -224,14 +224,14 @@ class ARCPlanner(CEMPlanner):  # pylint: disable=too-many-instance-attributes
         self,
         elite_actions: torch.Tensor,
         elite_values: torch.Tensor,
-        info: dict[str, int | float],
+        info: dict[str, float],
     ) -> tuple[torch.Tensor, torch.Tensor]:  # pylint: disable-next=unused-argument
         """Update the mean and variance of the elite actions.
 
         Args:
             elite_actions (torch.Tensor): The elite actions.
             elite_values (torch.Tensor): The elite values.
-            info (dict[str, int | float]): The dictionary containing the information of the elite values and actions.
+            info (dict[str, float]): The dictionary containing the information of the elite values and actions.
 
         Returns:
             new_mean: The new mean of the elite actions.
@@ -261,7 +261,7 @@ class ARCPlanner(CEMPlanner):  # pylint: disable=too-many-instance-attributes
         return new_mean, new_var
 
     @torch.no_grad()
-    def output_action(self, state: torch.Tensor) -> tuple[torch.Tensor, dict[str, int | float]]:
+    def output_action(self, state: torch.Tensor) -> tuple[torch.Tensor, dict[str, float]]:
         """Output the action given the state.
 
         Args:

--- a/omnisafe/algorithms/model_based/planner/cem.py
+++ b/omnisafe/algorithms/model_based/planner/cem.py
@@ -198,14 +198,14 @@ class CEMPlanner:  # pylint: disable=too-many-instance-attributes
         self,
         elite_actions: torch.Tensor,
         elite_values: torch.Tensor,
-        info: dict[str, int | float],
+        info: dict[str, float],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Update the mean and variance of the elite actions.
 
         Args:
             elite_actions (torch.Tensor): The elite actions.
             elite_values (torch.Tensor): The elite values.
-            info (dict[str, int | float]): The dictionary containing the information of the elite values and actions.
+            info (dict[str, float]): The dictionary containing the information of the elite values and actions.
 
         Returns:
             new_mean: The new mean of the elite actions.

--- a/omnisafe/algorithms/model_based/planner/safe_arc.py
+++ b/omnisafe/algorithms/model_based/planner/safe_arc.py
@@ -69,14 +69,14 @@ class SafeARCPlanner(ARCPlanner):
         self,
         elite_actions: torch.Tensor,
         elite_values: torch.Tensor,
-        info: dict[str, int | float],
+        info: dict[str, float],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Update the mean and variance of the elite actions.
 
         Args:
             elite_actions (torch.Tensor): The elite actions.
             elite_values (torch.Tensor): The elite values.
-            info (dict[str, int | float]): The dictionary containing the information of the elite values and actions.
+            info (dict[str, float]): The dictionary containing the information of the elite values and actions.
 
         Returns:
             new_mean: The new mean of the elite actions.
@@ -197,7 +197,7 @@ class SafeARCPlanner(ARCPlanner):
         return elite_values, elite_actions, info
 
     @torch.no_grad()
-    def output_action(self, state: torch.Tensor) -> tuple[torch.Tensor, dict[str, int | float]]:
+    def output_action(self, state: torch.Tensor) -> tuple[torch.Tensor, dict[str, float]]:
         """Output the action given the state.
 
         Args:
@@ -217,7 +217,7 @@ class SafeARCPlanner(ARCPlanner):
 
         current_iter = 0
         actions_actor = self._act_from_actor(state)
-        info: dict[str, int | float] = {}
+        info: dict[str, float] = {}
         while current_iter < self._num_iterations and last_var.max() > self._epsilon:
             actions_gauss = self._act_from_last_gaus(last_mean=last_mean, last_var=last_var)
             actions = torch.cat([actions_gauss, actions_actor], dim=1)

--- a/omnisafe/common/logger.py
+++ b/omnisafe/common/logger.py
@@ -117,11 +117,11 @@ class Logger:  # pylint: disable=too-many-instance-attributes
         self._epoch: int = 0
         self._first_row: bool = True
         self._what_to_save: dict[str, Any] | None = None
-        self._data: dict[str, deque[int | float] | list[int | float]] = {}
+        self._data: dict[str, deque[float] | list[float]] = {}
         self._headers_windows: dict[str, int | None] = {}
         self._headers_minmax: dict[str, bool] = {}
         self._headers_delta: dict[str, bool] = {}
-        self._current_row: dict[str, int | float] = {}
+        self._current_row: dict[str, float] = {}
 
         if config is not None:
             self.save_config(config)
@@ -257,7 +257,7 @@ class Logger:  # pylint: disable=too-many-instance-attributes
             The data stored in ``data`` will be updated by ``kwargs``.
 
         Args:
-            data (dict[str, int | float | np.ndarray | torch.Tensor] or None, optional): The data to
+            data (dict[str, float | np.ndarray | torch.Tensor] or None, optional): The data to
                 be stored. Defaults to None.
 
         Keyword Args:
@@ -340,7 +340,7 @@ class Logger:  # pylint: disable=too-many-instance-attributes
         self,
         key: str,
         min_and_max: bool = False,
-    ) -> tuple[int | float, ...]:
+    ) -> tuple[float, ...]:
         """Get the statistics of the key.
 
         Args:

--- a/omnisafe/envs/core.py
+++ b/omnisafe/envs/core.py
@@ -124,7 +124,11 @@ class CMDP(ABC):
         """
 
     @abstractmethod
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         Args:
@@ -237,7 +241,11 @@ class Wrapper(CMDP):
         """
         return self._env.step(action)
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         Args:
@@ -247,7 +255,7 @@ class Wrapper(CMDP):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        return self._env.reset(seed)
+        return self._env.reset(seed=seed, options=options)
 
     def set_seed(self, seed: int) -> None:
         """Set the seed for this env's random number generator(s).

--- a/omnisafe/envs/core.py
+++ b/omnisafe/envs/core.py
@@ -132,7 +132,8 @@ class CMDP(ABC):
         """Reset the environment and returns an initial observation.
 
         Args:
-            seed (int or None): Seed for the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
         Returns:
             observation: The initial observation of the space.
@@ -249,7 +250,9 @@ class Wrapper(CMDP):
         """Reset the environment and returns an initial observation.
 
         Args:
-            seed (int or None): Seed for the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
 
         Returns:
             observation: The initial observation of the space.

--- a/omnisafe/envs/mujoco_env.py
+++ b/omnisafe/envs/mujoco_env.py
@@ -142,7 +142,11 @@ class MujocoEnv(CMDP):
 
         return obs, reward, cost, terminated, truncated, info
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict]:
         """Reset the environment.
 
         Args:
@@ -152,7 +156,7 @@ class MujocoEnv(CMDP):
             observation: Agent's observation of the current environment.
             info: Auxiliary diagnostic information (helpful for debugging, and sometimes learning).
         """
-        obs, info = self._env.reset(seed=seed)
+        obs, info = self._env.reset(seed=seed, options=options)
         return torch.as_tensor(obs, dtype=torch.float32, device=self._device), info
 
     def set_seed(self, seed: int) -> None:

--- a/omnisafe/envs/mujoco_env.py
+++ b/omnisafe/envs/mujoco_env.py
@@ -150,7 +150,8 @@ class MujocoEnv(CMDP):
         """Reset the environment.
 
         Args:
-            seed (int, optional): Seed to reset the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
         Returns:
             observation: Agent's observation of the current environment.

--- a/omnisafe/envs/safety_gymnasium_env.py
+++ b/omnisafe/envs/safety_gymnasium_env.py
@@ -209,7 +209,11 @@ class SafetyGymnasiumEnv(CMDP):
 
         return obs, reward, cost, terminated, truncated, info
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment.
 
         Args:
@@ -220,7 +224,7 @@ class SafetyGymnasiumEnv(CMDP):
             observation: Agent's observation of the current environment.
             info: Some information logged by the environment.
         """
-        obs, info = self._env.reset(seed=seed)
+        obs, info = self._env.reset(seed=seed, options=options)
         return torch.as_tensor(obs, dtype=torch.float32, device=self._device), info
 
     def set_seed(self, seed: int) -> None:

--- a/omnisafe/envs/safety_gymnasium_env.py
+++ b/omnisafe/envs/safety_gymnasium_env.py
@@ -217,8 +217,9 @@ class SafetyGymnasiumEnv(CMDP):
         """Reset the environment.
 
         Args:
-            seed (int or None, optional): Seed to reset the environment.
-                Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
 
         Returns:
             observation: Agent's observation of the current environment.

--- a/omnisafe/envs/safety_gymnasium_modelbased.py
+++ b/omnisafe/envs/safety_gymnasium_modelbased.py
@@ -465,7 +465,11 @@ class SafetyGymnasiumModelBased(CMDP):  # pylint: disable=too-many-instance-attr
 
         return obs, reward, cost, terminated, truncated, info
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment.
 
         Args:
@@ -475,7 +479,7 @@ class SafetyGymnasiumModelBased(CMDP):  # pylint: disable=too-many-instance-attr
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        obs_original, info = self._env.reset(seed=seed)
+        obs_original, info = self._env.reset(seed=seed, options=options)
         if self._task == 'Goal':
             self.goal_position = self._env.task.goal.pos
             self.robot_position = self._env.task.agent.pos

--- a/omnisafe/envs/safety_gymnasium_modelbased.py
+++ b/omnisafe/envs/safety_gymnasium_modelbased.py
@@ -473,7 +473,9 @@ class SafetyGymnasiumModelBased(CMDP):  # pylint: disable=too-many-instance-attr
         """Reset the environment.
 
         Args:
-            seed (int, optional): Seed to reset the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
+
 
         Returns:
             observation: The initial observation of the space.

--- a/omnisafe/envs/wrapper.py
+++ b/omnisafe/envs/wrapper.py
@@ -52,7 +52,11 @@ class TimeLimit(Wrapper):
         self._time: int = 0
         self._time_limit: int = time_limit
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment.
 
         .. note::
@@ -66,7 +70,7 @@ class TimeLimit(Wrapper):
             info: Some information logged by the environment.
         """
         self._time = 0
-        return super().reset(seed)
+        return super().reset(seed=seed, options=options)
 
     def step(
         self,
@@ -235,7 +239,11 @@ class ObsNormalize(Wrapper):
         obs = self._obs_normalizer.normalize(obs)
         return obs, reward, cost, terminated, truncated, info
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns an initial observation.
 
         Args:
@@ -245,7 +253,7 @@ class ObsNormalize(Wrapper):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        obs, info = super().reset(seed)
+        obs, info = super().reset(seed=seed, options=options)
         info['original_obs'] = obs
         obs = self._obs_normalizer.normalize(obs)
         return obs, info
@@ -614,7 +622,11 @@ class Unsqueeze(Wrapper):
 
         return obs, reward, cost, terminated, truncated, info
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict[str, Any]]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Reset the environment and returns a new observation.
 
         .. note::
@@ -627,7 +639,7 @@ class Unsqueeze(Wrapper):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        obs, info = super().reset(seed)
+        obs, info = super().reset(seed=seed, options=options)
         obs = obs.unsqueeze(0)
         for k, v in info.items():
             if isinstance(v, torch.Tensor):

--- a/omnisafe/envs/wrapper.py
+++ b/omnisafe/envs/wrapper.py
@@ -63,7 +63,8 @@ class TimeLimit(Wrapper):
             Additionally, the time step will be reset to 0.
 
         Args:
-            seed (int or None, optional): The seed for the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
         Returns:
             observation: The initial observation of the space.
@@ -247,7 +248,8 @@ class ObsNormalize(Wrapper):
         """Reset the environment and returns an initial observation.
 
         Args:
-            seed (int or None, optional): Seed for the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
         Returns:
             observation: The initial observation of the space.
@@ -633,7 +635,8 @@ class Unsqueeze(Wrapper):
             The vector information will be unsqueezed to (1, dim) for agent training.
 
         Args:
-            seed (int or None, optional): Set the seed for the environment. Defaults to None.
+            seed (int, optional): The random seed. Defaults to None.
+            options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
         Returns:
             observation: The initial observation of the space.

--- a/omnisafe/envs/wrapper.py
+++ b/omnisafe/envs/wrapper.py
@@ -442,8 +442,8 @@ class ActionScale(Wrapper):
         self,
         env: CMDP,
         device: torch.device,
-        low: int | float,
-        high: int | float,
+        low: float,
+        high: float,
     ) -> None:
         """Initialize an instance of :class:`ActionScale`."""
         super().__init__(env=env, device=device)

--- a/omnisafe/utils/distributed.py
+++ b/omnisafe/utils/distributed.py
@@ -245,7 +245,7 @@ def avg_params(module: torch.nn.Module) -> None:
             param_tensor[:] = avg_param_tensor[:]
 
 
-def dist_avg(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
+def dist_avg(value: np.ndarray | torch.Tensor | float) -> torch.Tensor:
     """Average a tensor over distributed processes.
 
     Examples:
@@ -265,7 +265,7 @@ def dist_avg(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
     return dist_sum(value) / world_size()
 
 
-def dist_max(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
+def dist_max(value: np.ndarray | torch.Tensor | float) -> torch.Tensor:
     """Determine global maximum of tensor over distributed processes.
 
     Examples:
@@ -285,7 +285,7 @@ def dist_max(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
     return dist_op(value, ReduceOp.MAX)
 
 
-def dist_min(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
+def dist_min(value: np.ndarray | torch.Tensor | float) -> torch.Tensor:
     """Determine global minimum of tensor over distributed processes.
 
     Examples:
@@ -305,7 +305,7 @@ def dist_min(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
     return dist_op(value, ReduceOp.MIN)
 
 
-def dist_sum(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
+def dist_sum(value: np.ndarray | torch.Tensor | float) -> torch.Tensor:
     """Sum a tensor over distributed processes.
 
     Examples:
@@ -325,7 +325,7 @@ def dist_sum(value: np.ndarray | torch.Tensor | int | float) -> torch.Tensor:
     return dist_op(value, ReduceOp.SUM)
 
 
-def dist_op(value: np.ndarray | torch.Tensor | int | float, operation: Any) -> torch.Tensor:
+def dist_op(value: np.ndarray | torch.Tensor | float, operation: Any) -> torch.Tensor:
     """Multi-processing operation.
 
     .. note::

--- a/omnisafe/utils/model.py
+++ b/omnisafe/utils/model.py
@@ -46,7 +46,7 @@ def initialize_layer(init_function: InitFunction, layer: nn.Linear) -> None:
 
 def get_activation(
     activation: Activation,
-) -> type[nn.Identity] | type[nn.ReLU] | type[nn.Sigmoid] | type[nn.Softplus] | type[nn.Tanh]:
+) -> type[nn.Identity | nn.ReLU | nn.Sigmoid | nn.Softplus | nn.Tanh]:
     """Get the activation function.
 
     The ``activation`` can be chosen from: ``identity``, ``relu``, ``sigmoid``, ``softplus``,

--- a/omnisafe/utils/schedule.py
+++ b/omnisafe/utils/schedule.py
@@ -29,7 +29,7 @@ class Schedule(ABC):
     """Schedule for a value based on the step."""
 
     @abstractmethod
-    def value(self, time: int | float) -> int | float:
+    def value(self, time: float) -> float:
         """Value at time t."""
 
 
@@ -50,16 +50,16 @@ class PiecewiseSchedule(Schedule):
     def __init__(
         self,
         endpoints: list[tuple[int, float]],
-        outside_value: int | float,
+        outside_value: float,
     ) -> None:
         """Initialize an instance of :class:`PiecewiseSchedule`."""
         idxes = [e[0] for e in endpoints]
         assert idxes == sorted(idxes)
         self._interpolation: Callable[[float, float, float], float] = _linear_interpolation
-        self._outside_value: int | float = outside_value
+        self._outside_value: float = outside_value
         self._endpoints: list[tuple[int, float]] = endpoints
 
-    def value(self, time: int | float) -> int | float:
+    def value(self, time: float) -> float:
         """Value at time t.
 
         Args:
@@ -89,7 +89,7 @@ class ConstantSchedule(Schedule):
         """Initialize an instance of :class:`ConstantSchedule`."""
         self._v: float = value
 
-    def value(self, time: int | float) -> int | float:  # pylint: disable=unused-argument
+    def value(self, time: float) -> float:  # pylint: disable=unused-argument
         """Value at time t.
 
         Args:

--- a/tests/simple_env.py
+++ b/tests/simple_env.py
@@ -64,7 +64,11 @@ class SimpleEnv(CMDP):
         truncated = torch.as_tensor(self._count > 10)
         return obs, reward, cost, termiated, truncated, {'final_observation': obs}
 
-    def reset(self, seed: int | None = None) -> tuple[torch.Tensor, dict]:
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict]:
         if seed is not None:
             self.set_seed(seed)
         obs = torch.as_tensor(self._observation_space.sample())


### PR DESCRIPTION
# Description

The ``reset`` functions in wrapper, env and adapter are not suitable for [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) style API, which miss an ``option`` argument. This pull request add this interface and would not affect the previous usage and performance.

## Motivation and Context

It solves issue #265 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
