### PR TITLE
docs: pin dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==7.1.2
 sphinx-copybutton
 sphinx-design
 sphinx-press-theme


### PR DESCRIPTION
# Description

Pin the version of ``sphinx`` as 7.1.2.

## Motivation and Context

Some issue exists in the 7.2.3 version of ``sphinx``.
Read the docs would fail building the online documentation.
The error information is:
```python
  File "/home/docs/checkouts/readthedocs.org/user_builds/omnisafe/envs/latest/lib/python3.9/site-packages/torch/__init__.py", line 1157, in <module>
    from torch._C._VariableFunctions import *  # type: ignore[misc] # noqa: F403
ModuleNotFoundError: No module named 'torch._C._VariableFunctions'; 'torch._C' is not a package
```

So this pull request pin the version of ``sphinx`` in 7.1.2 to solve it.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
