### PR TITLE
deps: pin pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "typing-extensions >= 4.0.0",
     "typer[all] >= 0.7.0",
     "seaborn >= 0.12.2",
-    "pandas >=  1.5.3",
+    "pandas == 2.0.3",
     "matplotlib >= 3.7.1",
     "gdown >= 4.6.0"
 ]


### PR DESCRIPTION
# Description

Pin the version of pandas as 2.0.3.

## Motivation and Context

Since the [seaborn](https://github.com/mwaskom/seaborn) host in pypi do not support the latest version of [pandas](), some warning may arise in Python version higher than 3.9, like:
```bash
FAILED test_policy.py::test_workflow_for_training[algo(PPO)] - FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead
FAILED test_policy.py::test_workflow_for_training[algo(SAC)] - FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead
FAILED test_policy.py::test_workflow_for_training[algo(PPOLag)] - FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead
```
For more details please refer to [here](https://github.com/mwaskom/seaborn/issues/3464).

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
