### PR TITLE
feat: support discrete environment

### DIFF
--- a/docs/source/envs/discrete_env.rst
+++ b/docs/source/envs/discrete_env.rst
@@ -1,0 +1,18 @@
+OmniSafe Discrete Environment
+=============================
+
+.. currentmodule:: omnisafe.envs.discrete_env
+
+Discrete Environment Interface
+------------------------------
+
+.. card::
+    :class-header: sd-bg-success sd-text-white
+    :class-card: sd-outline-success  sd-rounded-1
+
+    Documentation
+    ^^^
+
+    .. autoclass:: DiscreteEnv
+        :members:
+        :private-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -461,6 +461,7 @@ this project, don't hesitate to ask your question on `the GitHub issue page <htt
     envs/wrapper
     envs/safety_gymnasium
     envs/mujoco_env
+    envs/discrete_env
     envs/adapter
 
 

--- a/docs/source/model/actor.rst
+++ b/docs/source/model/actor.rst
@@ -109,3 +109,17 @@ VAE Actor
     .. autoclass:: VAE
         :members:
         :private-members:
+
+Categorical Actor
+-----------------
+
+.. card::
+    :class-header: sd-bg-success sd-text-white
+    :class-card: sd-outline-success  sd-rounded-1
+
+    Documentation
+    ^^^
+
+    .. autoclass:: CategoricalActor
+        :members:
+        :private-members:

--- a/docs/source/saferl/lag.rst
+++ b/docs/source/saferl/lag.rst
@@ -233,7 +233,7 @@ Policy update
 
             .. math::
 
-                \min _\lambda(1-\lambda) [J^R(\pi)-\lambda J^C(\pi)] \\
+                \min _{\lambda} (J^R(\pi)-\lambda (J^C(\pi)-d)) \\
                 \text { s.t. } \lambda \geq 0
 
 

--- a/omnisafe/adapter/online_adapter.py
+++ b/omnisafe/adapter/online_adapter.py
@@ -109,8 +109,13 @@ class OnlineAdapter:
             cost_normalize (bool, optional): Whether to normalize the cost. Defaults to True.
         """
         if self._env.need_time_limit_wrapper:
-            self._env = TimeLimit(self._env, time_limit=1000, device=self._device)
-            self._eval_env = TimeLimit(self._eval_env, time_limit=1000, device=self._device)
+            time_limit = (
+                self._cfgs.train_cfgs.time_limit
+                if hasattr(self._cfgs.train_cfgs, 'time_limit')
+                else 1000
+            )
+            self._env = TimeLimit(self._env, time_limit=time_limit, device=self._device)
+            self._eval_env = TimeLimit(self._eval_env, time_limit=time_limit, device=self._device)
         if self._env.need_auto_reset_wrapper:
             self._env = AutoReset(self._env, device=self._device)
             self._eval_env = AutoReset(self._eval_env, device=self._device)
@@ -121,8 +126,9 @@ class OnlineAdapter:
             self._env = RewardNormalize(self._env, device=self._device)
         if cost_normalize:
             self._env = CostNormalize(self._env, device=self._device)
-        self._env = ActionScale(self._env, low=-1.0, high=1.0, device=self._device)
-        self._eval_env = ActionScale(self._eval_env, low=-1.0, high=1.0, device=self._device)
+        if self._env.need_action_scale_wrapper:
+            self._env = ActionScale(self._env, low=-1.0, high=1.0, device=self._device)
+            self._eval_env = ActionScale(self._eval_env, low=-1.0, high=1.0, device=self._device)
         if self._env.num_envs == 1:
             self._env = Unsqueeze(self._env, device=self._device)
         self._eval_env = Unsqueeze(self._eval_env, device=self._device)

--- a/omnisafe/algorithms/algo_wrapper.py
+++ b/omnisafe/algorithms/algo_wrapper.py
@@ -24,7 +24,7 @@ import torch
 
 from omnisafe.algorithms import ALGORITHM2TYPE, ALGORITHMS, registry
 from omnisafe.algorithms.base_algo import BaseAlgo
-from omnisafe.envs import support_envs
+from omnisafe.envs import ENVIRONMNET2TYPE, support_envs
 from omnisafe.evaluator import Evaluator
 from omnisafe.utils import distributed
 from omnisafe.utils.config import Config, check_all_configs, get_default_kwargs_yaml
@@ -88,6 +88,7 @@ class AlgoWrapper:
             self.algo in ALGORITHMS['all']
         ), f"{self.algo} doesn't exist. Please choose from {ALGORITHMS['all']}."
         self.algo_type = ALGORITHM2TYPE.get(self.algo, '')
+        self.env_type = ENVIRONMNET2TYPE.get(self.env_id, '')
         if self.train_terminal_cfgs is not None:
             if self.algo_type in ['model-based', 'offline']:
                 assert (
@@ -146,7 +147,7 @@ class AlgoWrapper:
 
     def _init_algo(self) -> None:
         """Initialize the algorithm."""
-        check_all_configs(self.cfgs, self.algo_type)
+        check_all_configs(self.cfgs, self.algo_type, self.env_type)
         if distributed.fork(
             self.cfgs.train_cfgs.parallel,
             device=self.cfgs.train_cfgs.device,

--- a/omnisafe/algorithms/on_policy/base/policy_gradient.py
+++ b/omnisafe/algorithms/on_policy/base/policy_gradient.py
@@ -555,15 +555,15 @@ class PolicyGradient(BaseAlgo):
         """
         distribution = self._actor_critic.actor(obs)
         logp_ = self._actor_critic.actor.log_prob(act)
-        std = self._actor_critic.actor.std
         ratio = torch.exp(logp_ - logp)
         loss = -(ratio * adv).mean()
         entropy = distribution.entropy().mean().item()
+        if self._cfgs.model_cfgs.actor_type == 'gaussian_learning':
+            self._logger.store({'Train/PolicyStd': self._actor_critic.actor.std})
         self._logger.store(
             {
                 'Train/Entropy': entropy,
                 'Train/PolicyRatio': ratio,
-                'Train/PolicyStd': std,
                 'Loss/Loss_pi': loss.mean().item(),
             },
         )

--- a/omnisafe/algorithms/on_policy/base/ppo.py
+++ b/omnisafe/algorithms/on_policy/base/ppo.py
@@ -65,7 +65,6 @@ class PPO(PolicyGradient):
         """
         distribution = self._actor_critic.actor(obs)
         logp_ = self._actor_critic.actor.log_prob(act)
-        std = self._actor_critic.actor.std
         ratio = torch.exp(logp_ - logp)
         ratio_cliped = torch.clamp(
             ratio,
@@ -76,11 +75,12 @@ class PPO(PolicyGradient):
         loss -= self._cfgs.algo_cfgs.entropy_coef * distribution.entropy().mean()
         # useful extra info
         entropy = distribution.entropy().mean().item()
+        if self._cfgs.model_cfgs.actor_type == 'gaussian_learning':
+            self._logger.store({'Train/PolicyStd': self._actor_critic.actor.std})
         self._logger.store(
             {
                 'Train/Entropy': entropy,
                 'Train/PolicyRatio': ratio,
-                'Train/PolicyStd': std,
                 'Loss/Loss_pi': loss.mean().item(),
             },
         )

--- a/omnisafe/common/buffer/base.py
+++ b/omnisafe/common/buffer/base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 import torch
-from gymnasium.spaces import Box
+from gymnasium.spaces import Box, Discrete
 
 from omnisafe.typing import DEVICE_CPU, OmnisafeSpace
 
@@ -57,8 +57,8 @@ class BaseBuffer(ABC):
         data (dict[str, torch.Tensor]): The data of the buffer.
 
     Raises:
-        NotImplementedError: If the observation space or the action space is not Box.
-        NotImplementedError: If the action space or the action space is not Box.
+        NotImplementedError: If the observation space or the action space is not Box nor Discrete.
+        NotImplementedError: If the action space or the action space is not Box nor Discrete.
     """
 
     def __init__(
@@ -72,10 +72,14 @@ class BaseBuffer(ABC):
         self._device: torch.device = device
         if isinstance(obs_space, Box):
             obs_buf = torch.zeros((size, *obs_space.shape), dtype=torch.float32, device=device)
+        elif isinstance(obs_space, Discrete):
+            obs_buf = torch.zeros((size, 1), dtype=torch.float32, device=device)
         else:
             raise NotImplementedError
         if isinstance(act_space, Box):
             act_buf = torch.zeros((size, *act_space.shape), dtype=torch.float32, device=device)
+        elif isinstance(act_space, Discrete):
+            act_buf = torch.zeros((size), dtype=torch.float32, device=device)
         else:
             raise NotImplementedError
 

--- a/omnisafe/common/buffer/base.py
+++ b/omnisafe/common/buffer/base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+import numpy as np
 import torch
 from gymnasium.spaces import Box, Discrete
 
@@ -70,16 +71,23 @@ class BaseBuffer(ABC):
     ) -> None:
         """Initialize an instance of :class:`BaseBuffer`."""
         self._device: torch.device = device
-        if isinstance(obs_space, Box):
-            obs_buf = torch.zeros((size, *obs_space.shape), dtype=torch.float32, device=device)
-        elif isinstance(obs_space, Discrete):
-            obs_buf = torch.zeros((size, 1), dtype=torch.float32, device=device)
+
+        if isinstance(obs_space, (Box, Discrete)):
+            obs_buf = torch.zeros(
+                (size, int(np.array(obs_space.shape).prod())),
+                dtype=torch.float32,
+                device=device,
+            )
         else:
             raise NotImplementedError
-        if isinstance(act_space, Box):
-            act_buf = torch.zeros((size, *act_space.shape), dtype=torch.float32, device=device)
-        elif isinstance(act_space, Discrete):
-            act_buf = torch.zeros((size), dtype=torch.float32, device=device)
+
+        if isinstance(act_space, (Box, Discrete)):
+            act_buf = torch.zeros(
+                (size, int(np.array(act_space.shape).prod())),
+                dtype=torch.float32,
+                device=device,
+            )
+
         else:
             raise NotImplementedError
 

--- a/omnisafe/common/buffer/base.py
+++ b/omnisafe/common/buffer/base.py
@@ -28,7 +28,7 @@ class BaseBuffer(ABC):
     r"""Abstract base class for buffer.
 
     .. warning::
-        The buffer only supports Box spaces.
+        The buffer only supports ``Box`` and ``Discrete`` spaces.
 
     In base buffer, we store the following data:
 

--- a/omnisafe/common/buffer/onpolicy_buffer.py
+++ b/omnisafe/common/buffer/onpolicy_buffer.py
@@ -31,7 +31,7 @@ class OnPolicyBuffer(BaseBuffer):  # pylint: disable=too-many-instance-attribute
     state-action pairs, ranging from ``GAE``, ``GAE-RTG`` , ``V-trace`` to ``Plain`` method.
 
     .. warning::
-        The buffer only supports Box spaces.
+        The buffer only supports ``Box`` and ``Discrete`` spaces.
 
     Compared to the base buffer, the on-policy buffer stores extra data:
 

--- a/omnisafe/common/buffer/vector_onpolicy_buffer.py
+++ b/omnisafe/common/buffer/vector_onpolicy_buffer.py
@@ -30,7 +30,7 @@ class VectorOnPolicyBuffer(OnPolicyBuffer):
     stored in a list of on-policy buffers, each of which corresponds to one environment.
 
     .. warning::
-        The buffer only supports Box spaces.
+        The buffer only supports ``Box`` and ``Discrete`` spaces.
 
     Args:
         obs_space (OmnisafeSpace): Observation space.

--- a/omnisafe/configs/on-policy/CPO.yaml
+++ b/omnisafe/configs/on-policy/CPO.yaml
@@ -126,3 +126,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/CPO.yaml
+++ b/omnisafe/configs/on-policy/CPO.yaml
@@ -131,7 +131,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -147,17 +147,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/CPPOPID.yaml
+++ b/omnisafe/configs/on-policy/CPPOPID.yaml
@@ -147,7 +147,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -163,11 +163,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/CPPOPID.yaml
+++ b/omnisafe/configs/on-policy/CPPOPID.yaml
@@ -142,3 +142,39 @@ defaults:
     penalty_max: 100.0
     # Initial value of lagrangian multiplier
     lagrangian_multiplier_init: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/IPO.yaml
+++ b/omnisafe/configs/on-policy/IPO.yaml
@@ -139,7 +139,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -155,11 +155,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/IPO.yaml
+++ b/omnisafe/configs/on-policy/IPO.yaml
@@ -134,3 +134,39 @@ defaults:
     lambda_lr: 0.035
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/NaturalPG.yaml
+++ b/omnisafe/configs/on-policy/NaturalPG.yaml
@@ -126,3 +126,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/NaturalPG.yaml
+++ b/omnisafe/configs/on-policy/NaturalPG.yaml
@@ -131,7 +131,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -147,17 +147,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/OnCRPO.yaml
+++ b/omnisafe/configs/on-policy/OnCRPO.yaml
@@ -128,3 +128,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/OnCRPO.yaml
+++ b/omnisafe/configs/on-policy/OnCRPO.yaml
@@ -133,7 +133,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -149,17 +149,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/P3O.yaml
+++ b/omnisafe/configs/on-policy/P3O.yaml
@@ -127,7 +127,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -143,11 +143,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/P3O.yaml
+++ b/omnisafe/configs/on-policy/P3O.yaml
@@ -122,3 +122,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.0003
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/PCPO.yaml
+++ b/omnisafe/configs/on-policy/PCPO.yaml
@@ -126,3 +126,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/PCPO.yaml
+++ b/omnisafe/configs/on-policy/PCPO.yaml
@@ -131,7 +131,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -147,17 +147,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/PDO.yaml
+++ b/omnisafe/configs/on-policy/PDO.yaml
@@ -127,3 +127,40 @@ defaults:
     lambda_lr: 0.035
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/PDO.yaml
+++ b/omnisafe/configs/on-policy/PDO.yaml
@@ -133,7 +133,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -149,11 +149,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/PPO.yaml
+++ b/omnisafe/configs/on-policy/PPO.yaml
@@ -123,7 +123,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -139,11 +139,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/PPO.yaml
+++ b/omnisafe/configs/on-policy/PPO.yaml
@@ -118,3 +118,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.0003
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/PPOLag.yaml
+++ b/omnisafe/configs/on-policy/PPOLag.yaml
@@ -128,3 +128,39 @@ defaults:
     lambda_lr: 0.035
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/PPOLag.yaml
+++ b/omnisafe/configs/on-policy/PPOLag.yaml
@@ -133,7 +133,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -149,11 +149,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/PolicyGradient.yaml
+++ b/omnisafe/configs/on-policy/PolicyGradient.yaml
@@ -121,7 +121,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -137,11 +137,13 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation

--- a/omnisafe/configs/on-policy/PolicyGradient.yaml
+++ b/omnisafe/configs/on-policy/PolicyGradient.yaml
@@ -116,3 +116,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.0003
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/RCPO.yaml
+++ b/omnisafe/configs/on-policy/RCPO.yaml
@@ -139,7 +139,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -155,17 +155,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/RCPO.yaml
+++ b/omnisafe/configs/on-policy/RCPO.yaml
@@ -134,3 +134,39 @@ defaults:
     lambda_lr: 0.035
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/TRPO.yaml
+++ b/omnisafe/configs/on-policy/TRPO.yaml
@@ -129,7 +129,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -145,17 +145,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/TRPO.yaml
+++ b/omnisafe/configs/on-policy/TRPO.yaml
@@ -124,3 +124,39 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/TRPOLag.yaml
+++ b/omnisafe/configs/on-policy/TRPOLag.yaml
@@ -139,7 +139,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -155,17 +155,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/configs/on-policy/TRPOLag.yaml
+++ b/omnisafe/configs/on-policy/TRPOLag.yaml
@@ -134,3 +134,39 @@ defaults:
     lambda_lr: 0.035
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/TRPOPID.yaml
+++ b/omnisafe/configs/on-policy/TRPOPID.yaml
@@ -150,3 +150,39 @@ defaults:
     penalty_max: 100.0
     # Initial value of lagrangian multiplier
     lagrangian_multiplier_init: 0.001
+
+CartPole-v1:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 500
+    # total number of steps to train
+    total_steps: 1000000
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"
+
+Taxi-v3:
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 5
+  # training configurations
+  train_cfgs:
+    # max time-step for each episode
+    time_limit: 200
+  # algorithm configurations
+  algo_cfgs:
+    # normalize observation
+    obs_normalize: False
+    # entropy coefficient
+    entropy_coef: 0.01
+  # model configurations
+  model_cfgs:
+    # actor type, options: gaussian, gaussian_learning
+    actor_type: "discrete"

--- a/omnisafe/configs/on-policy/TRPOPID.yaml
+++ b/omnisafe/configs/on-policy/TRPOPID.yaml
@@ -155,7 +155,7 @@ CartPole-v1:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
@@ -171,17 +171,17 @@ Taxi-v3:
   # logger configurations
   logger_cfgs:
     # save model frequency
-    save_model_freq: 5
+    save_model_freq: 10
   # training configurations
   train_cfgs:
     # max time-step for each episode
     time_limit: 200
+    # total number of steps to train
+    total_steps: 1000000
   # algorithm configurations
   algo_cfgs:
     # normalize observation
     obs_normalize: False
-    # entropy coefficient
-    entropy_coef: 0.01
   # model configurations
   model_cfgs:
     # actor type, options: gaussian, gaussian_learning

--- a/omnisafe/envs/__init__.py
+++ b/omnisafe/envs/__init__.py
@@ -14,7 +14,34 @@
 # ==============================================================================
 """Environment API for OmniSafe."""
 
+import itertools
+from types import MappingProxyType
+
 from omnisafe.envs.core import CMDP, env_register, make, support_envs
+from omnisafe.envs.discrete_env import DiscreteEnv
 from omnisafe.envs.mujoco_env import MujocoEnv
 from omnisafe.envs.safety_gymnasium_env import SafetyGymnasiumEnv
 from omnisafe.envs.safety_gymnasium_modelbased import SafetyGymnasiumModelBased
+
+
+ENVIRONMENTS = {
+    'box': tuple(
+        MujocoEnv.support_envs()
+        + SafetyGymnasiumEnv.support_envs()
+        + SafetyGymnasiumModelBased.support_envs(),
+    ),
+    'discrete': tuple(DiscreteEnv.support_envs()),
+}
+
+ENVIRONMNET2TYPE = {
+    env: env_type for env_type, environments in ENVIRONMENTS.items() for env in environments
+}
+
+__all__ = ENVIRONMENTS['all'] = tuple(itertools.chain.from_iterable(ENVIRONMENTS.values()))
+
+assert len(ENVIRONMNET2TYPE) == len(__all__), 'Duplicate algorithm names found.'
+
+ENVIRONMENTS = MappingProxyType(ENVIRONMENTS)  # make this immutable
+ENVIRONMNET2TYPE = MappingProxyType(ENVIRONMNET2TYPE)  # make this immutable
+
+del itertools, MappingProxyType

--- a/omnisafe/envs/core.py
+++ b/omnisafe/envs/core.py
@@ -53,6 +53,7 @@ class CMDP(ABC):
     _time_limit: int | None = None
     need_time_limit_wrapper: bool
     need_auto_reset_wrapper: bool
+    need_action_scale_wrapper: bool
 
     _support_envs: ClassVar[list[str]]
 

--- a/omnisafe/envs/core.py
+++ b/omnisafe/envs/core.py
@@ -259,7 +259,7 @@ class Wrapper(CMDP):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        return self._env.reset(seed=seed)
+        return self._env.reset(seed=seed, options=options)
 
     def set_seed(self, seed: int) -> None:
         """Set the seed for this env's random number generator(s).

--- a/omnisafe/envs/core.py
+++ b/omnisafe/envs/core.py
@@ -259,7 +259,7 @@ class Wrapper(CMDP):
             observation: The initial observation of the space.
             info: Some information logged by the environment.
         """
-        return self._env.reset(seed=seed, options=options)
+        return self._env.reset(seed=seed)
 
     def set_seed(self, seed: int) -> None:
         """Set the seed for this env's random number generator(s).

--- a/omnisafe/envs/discrete_env.py
+++ b/omnisafe/envs/discrete_env.py
@@ -32,7 +32,9 @@ class DiscreteEnv(CMDP):
     """Discrete Gymnasium Environment.
 
     This environment only served as an example to integrate discrete action and
-    observation environment into OmniSafe. We support ``CartPole-v1`` and ``Taxi-v3``.
+    observation environment into OmniSafe. We support
+    `CartPole-v1 <https://gymnasium.farama.org/environments/classic_control/cart_pole/>`_
+    and `Taxi-v3 <https://gymnasium.farama.org/environments/toy_text/taxi/>`_.
     The former is ``Box`` observation space and ``Discrete`` action space, while
     the latter is ``Discrete`` observation and ``Discrete`` action space.
 

--- a/omnisafe/envs/discrete_env.py
+++ b/omnisafe/envs/discrete_env.py
@@ -165,7 +165,6 @@ class DiscreteEnv(CMDP):
             seed (int, optional): The random seed. Defaults to None.
             options (dict[str, Any], optional): The options for the environment. Defaults to None.
 
-
         Returns:
             observation: Agent's observation of the current environment.
             info: Some information logged by the environment.

--- a/omnisafe/envs/discrete_env.py
+++ b/omnisafe/envs/discrete_env.py
@@ -128,7 +128,7 @@ class DiscreteEnv(CMDP):
             info: Some information logged by the environment.
         """
         obs, reward, terminated, truncated, info = self._env.step(
-            action.detach().cpu().numpy().tolist(),
+            action.detach().cpu().squeeze().numpy(),
         )
         obs, reward, terminated, truncated = (
             torch.as_tensor(x, dtype=torch.float32, device=self._device)

--- a/omnisafe/envs/discrete_env.py
+++ b/omnisafe/envs/discrete_env.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Environments in the Safety-Gymnasium."""
+"""Environments with discrete observation/action space in Gymnasium."""
 
 from __future__ import annotations
 
 from typing import Any, ClassVar
 
+import gymnasium
 import numpy as np
-import safety_gymnasium
 import torch
+from gymnasium import spaces
 
 from omnisafe.envs.core import CMDP, env_register
-from omnisafe.typing import DEVICE_CPU, Box
+from omnisafe.typing import DEVICE_CPU, Discrete
 
 
 @env_register
-class SafetyGymnasiumEnv(CMDP):
-    """Safety Gymnasium Environment.
+class DiscreteEnv(CMDP):
+    """Discrete Gymnasium Environment.
+
+    This environment only served as an example to integrate discrete action and
+    observation environment into OmniSafe. We support ``CartPole-v1`` and ``Taxi-v3``.
+    The former is ``Box`` observation space and ``Discrete`` action space, while
+    the latter is ``Discrete`` observation and ``Discrete`` action space.
 
     Args:
         env_id (str): Environment id.
@@ -39,90 +45,22 @@ class SafetyGymnasiumEnv(CMDP):
     Keyword Args:
         render_mode (str, optional): The render mode ranges from 'human' to 'rgb_array' and 'rgb_array_list'.
             Defaults to 'rgb_array'.
-        camera_name (str, optional): The camera name.
-        camera_id (int, optional): The camera id.
-        width (int, optional): The width of the rendered image. Defaults to 256.
-        height (int, optional): The height of the rendered image. Defaults to 256.
 
     Attributes:
         need_auto_reset_wrapper (bool): Whether to use auto reset wrapper.
         need_time_limit_wrapper (bool): Whether to use time limit wrapper.
+        need_action_repeat_wrapper (bool): Whether to use action repeat wrapper.
         need_action_scale_wrapper (bool): Whether to use action scale wrapper.
     """
 
+    need_action_scale_wrapper = False
+    need_obs_normalize_wrapper = False
     need_auto_reset_wrapper = False
     need_time_limit_wrapper = False
-    need_action_scale_wrapper = True
 
     _support_envs: ClassVar[list[str]] = [
-        'SafetyPointGoal0-v0',
-        'SafetyPointGoal1-v0',
-        'SafetyPointGoal2-v0',
-        'SafetyPointButton0-v0',
-        'SafetyPointButton1-v0',
-        'SafetyPointButton2-v0',
-        'SafetyPointPush0-v0',
-        'SafetyPointPush1-v0',
-        'SafetyPointPush2-v0',
-        'SafetyPointCircle0-v0',
-        'SafetyPointCircle1-v0',
-        'SafetyPointCircle2-v0',
-        'SafetyCarGoal0-v0',
-        'SafetyCarGoal1-v0',
-        'SafetyCarGoal2-v0',
-        'SafetyCarButton0-v0',
-        'SafetyCarButton1-v0',
-        'SafetyCarButton2-v0',
-        'SafetyCarPush0-v0',
-        'SafetyCarPush1-v0',
-        'SafetyCarPush2-v0',
-        'SafetyCarCircle0-v0',
-        'SafetyCarCircle1-v0',
-        'SafetyCarCircle2-v0',
-        'SafetyAntGoal0-v0',
-        'SafetyAntGoal1-v0',
-        'SafetyAntGoal2-v0',
-        'SafetyAntButton0-v0',
-        'SafetyAntButton1-v0',
-        'SafetyAntButton2-v0',
-        'SafetyAntPush0-v0',
-        'SafetyAntPush1-v0',
-        'SafetyAntPush2-v0',
-        'SafetyAntCircle0-v0',
-        'SafetyAntCircle1-v0',
-        'SafetyAntCircle2-v0',
-        'SafetyDoggoGoal0-v0',
-        'SafetyDoggoGoal1-v0',
-        'SafetyDoggoGoal2-v0',
-        'SafetyDoggoButton0-v0',
-        'SafetyDoggoButton1-v0',
-        'SafetyDoggoButton2-v0',
-        'SafetyDoggoPush0-v0',
-        'SafetyDoggoPush1-v0',
-        'SafetyDoggoPush2-v0',
-        'SafetyDoggoCircle0-v0',
-        'SafetyDoggoCircle1-v0',
-        'SafetyDoggoCircle2-v0',
-        'SafetyRacecarGoal0-v0',
-        'SafetyRacecarGoal1-v0',
-        'SafetyRacecarGoal2-v0',
-        'SafetyRacecarButton0-v0',
-        'SafetyRacecarButton1-v0',
-        'SafetyRacecarButton2-v0',
-        'SafetyRacecarPush0-v0',
-        'SafetyRacecarPush1-v0',
-        'SafetyRacecarPush2-v0',
-        'SafetyRacecarCircle0-v0',
-        'SafetyRacecarCircle1-v0',
-        'SafetyRacecarCircle2-v0',
-        'SafetyHalfCheetahVelocity-v1',
-        'SafetyHopperVelocity-v1',
-        'SafetySwimmerVelocity-v1',
-        'SafetyWalker2dVelocity-v1',
-        'SafetyAntVelocity-v1',
-        'SafetyHumanoidVelocity-v1',
-        'SafetyPointRun0-v0',
-        'SafetyCarRun0-v0',
+        'CartPole-v1',
+        'Taxi-v3',
     ]
 
     def __init__(
@@ -132,31 +70,29 @@ class SafetyGymnasiumEnv(CMDP):
         device: torch.device = DEVICE_CPU,
         **kwargs: Any,
     ) -> None:
-        """Initialize an instance of :class:`SafetyGymnasiumEnv`."""
+        """Initialize an instance of :class:`DiscreteEnv`."""
         super().__init__(env_id)
         self._num_envs = num_envs
         self._device = torch.device(device)
 
         if num_envs > 1:
-            self._env = safety_gymnasium.vector.make(env_id=env_id, num_envs=num_envs, **kwargs)
-            assert isinstance(self._env.single_action_space, Box), 'Only support Box action space.'
+            self._env = gymnasium.vector.make(
+                id=env_id,
+                num_envs=num_envs,
+                render_mode=kwargs.get('render_mode'),
+            )
             assert isinstance(
-                self._env.single_observation_space,
-                Box,
-            ), 'Only support Box observation space.'
+                self._env.single_action_space,
+                Discrete,
+            ), 'Only support Discrete action space.'
             self._action_space = self._env.single_action_space
-            self._observation_space = self._env.single_observation_space
+            self._observation_space = self._env.single_observation_space  # type: ignore
         else:
             self.need_time_limit_wrapper = True
             self.need_auto_reset_wrapper = True
-            self._env = safety_gymnasium.make(id=env_id, autoreset=True, **kwargs)
-            assert isinstance(self._env.action_space, Box), 'Only support Box action space.'
-            assert isinstance(
-                self._env.observation_space,
-                Box,
-            ), 'Only support Box observation space.'
-            self._action_space = self._env.action_space
-            self._observation_space = self._env.observation_space
+            self._env = gymnasium.make(id=env_id, autoreset=True, render_mode=kwargs.get('render_mode'))  # type: ignore
+            self._action_space = self._env.action_space  # type: ignore
+            self._observation_space = self._env.observation_space  # type: ignore
         self._metadata = self._env.metadata
 
     def step(
@@ -189,27 +125,32 @@ class SafetyGymnasiumEnv(CMDP):
             truncated: Whether the episode has been truncated due to a time limit.
             info: Some information logged by the environment.
         """
-        obs, reward, cost, terminated, truncated, info = self._env.step(
-            action.detach().cpu().numpy(),
+        obs, reward, terminated, truncated, info = self._env.step(
+            action.detach().cpu().numpy().tolist(),
         )
-        obs, reward, cost, terminated, truncated = (
+        obs, reward, terminated, truncated = (
             torch.as_tensor(x, dtype=torch.float32, device=self._device)
-            for x in (obs, reward, cost, terminated, truncated)
+            for x in (obs, reward, terminated, truncated)
         )
+        if isinstance(self._observation_space, spaces.Discrete):
+            obs = obs.unsqueeze(-1)
         if 'final_observation' in info:
-            info['final_observation'] = np.array(
-                [
-                    array if array is not None else np.zeros(obs.shape[-1])
-                    for array in info['final_observation']
-                ],
-            )
+            if isinstance(info['final_observation'], np.ndarray):
+                info['final_observation'] = np.array(
+                    [
+                        array if array is not None else np.zeros(obs.shape[-1])
+                        for array in info['final_observation']
+                    ],
+                )
             info['final_observation'] = torch.as_tensor(
                 info['final_observation'],
                 dtype=torch.float32,
                 device=self._device,
             )
+            if isinstance(self._observation_space, spaces.Discrete):
+                info['final_observation'] = info['final_observation'].unsqueeze(-1)
 
-        return obs, reward, cost, terminated, truncated, info
+        return obs, reward, torch.zeros_like(reward), terminated, truncated, info
 
     def reset(
         self,
@@ -228,7 +169,10 @@ class SafetyGymnasiumEnv(CMDP):
             info: Some information logged by the environment.
         """
         obs, info = self._env.reset(seed=seed, options=options)
-        return torch.as_tensor(obs, dtype=torch.float32, device=self._device), info
+        obs = torch.as_tensor(obs, dtype=torch.float32, device=self._device)
+        if isinstance(self._observation_space, spaces.Discrete):
+            obs = obs.unsqueeze(-1)
+        return obs, info
 
     def set_seed(self, seed: int) -> None:
         """Set the seed for the environment.
@@ -246,7 +190,7 @@ class SafetyGymnasiumEnv(CMDP):
         """
         return torch.as_tensor(
             self._env.action_space.sample(),
-            dtype=torch.float32,
+            dtype=torch.int64,
             device=self._device,
         )
 

--- a/omnisafe/envs/mujoco_env.py
+++ b/omnisafe/envs/mujoco_env.py
@@ -33,12 +33,15 @@ class MujocoEnv(CMDP):
     Attributes:
         need_auto_reset_wrapper (bool): Whether to use auto reset wrapper.
         need_time_limit_wrapper (bool): Whether to use time limit wrapper.
+        need_action_repeat_wrapper (bool): Whether to use action repeat wrapper.
+        need_action_scale_wrapper (bool): Whether to use action scale wrapper.
     """
 
     need_auto_reset_wrapper = True
-
     need_time_limit_wrapper = False
     need_action_repeat_wrapper = True
+    need_action_scale_wrapper = True
+
     _support_envs: ClassVar[list[str]] = [
         'Ant-v4',
         'Hopper-v4',

--- a/omnisafe/envs/safety_gymnasium_modelbased.py
+++ b/omnisafe/envs/safety_gymnasium_modelbased.py
@@ -36,10 +36,12 @@ class SafetyGymnasiumModelBased(CMDP):  # pylint: disable=too-many-instance-attr
         _support_envs (list[str]): List of supported environments.
         need_auto_reset_wrapper (bool): Whether to use auto reset wrapper.
         need_time_limit_wrapper (bool): Whether to use time limit wrapper.
+        need_action_scale_wrapper (bool): Whether to use action scale wrapper.
     """
 
     need_auto_reset_wrapper = False
     need_time_limit_wrapper = False
+    need_action_scale_wrapper = True
 
     _support_envs: ClassVar[list[str]] = [
         'SafetyPointGoal0-v0-modelbased',

--- a/omnisafe/envs/wrapper.py
+++ b/omnisafe/envs/wrapper.py
@@ -584,7 +584,10 @@ class Unsqueeze(Wrapper):
         """Initialize an instance of :class:`Unsqueeze`."""
         super().__init__(env=env, device=device)
         assert self.num_envs == 1, 'Unsqueeze only works with single environment'
-        assert isinstance(self.observation_space, spaces.Box), 'Observation space must be Box'
+        assert isinstance(
+            self.observation_space,
+            (spaces.Box, spaces.Discrete),
+        ), 'Observation space must be Box or Discrete'
 
     def step(
         self,

--- a/omnisafe/evaluator.py
+++ b/omnisafe/evaluator.py
@@ -163,8 +163,8 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes
             obs_normalizer.load_state_dict(model_params['obs_normalizer'])
             self._env = ObsNormalize(self._env, device=torch.device('cpu'), norm=obs_normalizer)
         if self._env.need_time_limit_wrapper:
-            self._cfgs['train_cfgs'].get('time_limit', 1000)
-            self._env = TimeLimit(self._env, device=torch.device('cpu'), time_limit=1000)
+            time_limit = self._cfgs['train_cfgs'].get('time_limit', 1000)
+            self._env = TimeLimit(self._env, device=torch.device('cpu'), time_limit=time_limit)
         if self._env.need_action_scale_wrapper:
             self._env = ActionScale(self._env, device=torch.device('cpu'), low=-1.0, high=1.0)
 
@@ -287,7 +287,6 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes
                     high=np.hstack((observation_space.high, np.inf)),
                     shape=(observation_space.shape[0] + 1,),
                 )
-            actor_type = self._cfgs['model_cfgs']['actor_type']
             pi_cfg = self._cfgs['model_cfgs']['actor']
             weight_initialization_mode = self._cfgs['model_cfgs']['weight_initialization_mode']
             actor_builder = ActorBuilder(
@@ -297,7 +296,7 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes
                 activation=pi_cfg['activation'],
                 weight_initialization_mode=weight_initialization_mode,
             )
-            self._actor = actor_builder.build_actor(actor_type)
+            self._actor = actor_builder.build_actor(self._cfgs['model_cfgs']['actor_type'])
             self._actor.load_state_dict(model_params['pi'])
 
     # pylint: disable-next=too-many-locals

--- a/omnisafe/models/actor/__init__.py
+++ b/omnisafe/models/actor/__init__.py
@@ -15,6 +15,7 @@
 """The abstract interfaces of Actor networks for the Actor-Critic algorithm."""
 
 from omnisafe.models.actor.actor_builder import ActorBuilder
+from omnisafe.models.actor.categorical_actor import CategoricalActor
 from omnisafe.models.actor.gaussian_actor import GaussianActor
 from omnisafe.models.actor.gaussian_learning_actor import GaussianLearningActor
 from omnisafe.models.actor.gaussian_sac_actor import GaussianSACActor

--- a/omnisafe/models/actor/categorical_actor.py
+++ b/omnisafe/models/actor/categorical_actor.py
@@ -1,0 +1,128 @@
+# Copyright 2023 OmniSafe Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Implementation of CategoricalActor."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch.distributions import Categorical, Distribution
+
+from omnisafe.models.base import Actor
+from omnisafe.typing import Activation, InitFunction, OmnisafeSpace
+from omnisafe.utils.model import build_mlp_network
+
+
+# pylint: disable-next=too-many-instance-attributes
+class CategoricalActor(Actor):
+    """Implementation of CategoricalActor.
+
+    CategoricalActor is an actor suitable for discrete action. It is used in
+    discrete action space environment such as ``CartPole-v1`` and so on.
+
+    Args:
+        obs_space (OmnisafeSpace): Observation space.
+        act_space (OmnisafeSpace): Action space.
+        hidden_sizes (list of int): List of hidden layer sizes.
+        activation (Activation, optional): Activation function. Defaults to ``'relu'``.
+        weight_initialization_mode (InitFunction, optional): Weight initialization mode. Defaults to
+            ``'kaiming_uniform'``.
+    """
+
+    _current_dist: Categorical
+
+    def __init__(
+        self,
+        obs_space: OmnisafeSpace,
+        act_space: OmnisafeSpace,
+        hidden_sizes: list[int],
+        activation: Activation = 'relu',
+        weight_initialization_mode: InitFunction = 'kaiming_uniform',
+    ) -> None:
+        """Initialize an instance of :class:`CategoricalActor`."""
+        super().__init__(obs_space, act_space, hidden_sizes, activation, weight_initialization_mode)
+
+        self.logits: nn.Module = build_mlp_network(
+            sizes=[self._obs_dim, *self._hidden_sizes, self._act_dim],
+            activation=activation,
+            weight_initialization_mode=weight_initialization_mode,
+        )
+
+    def _distribution(self, obs: torch.Tensor) -> Categorical:
+        """Get the distribution of the actor.
+
+        .. warning::
+            This method is not supposed to be called by users. You should call :meth:`forward`
+            instead.
+
+        Args:
+            obs (torch.Tensor): Observation from environments.
+
+        Returns:
+            Categorical distribution over actions based on the actor's logits.
+        """
+        logits = self.logits(obs)
+        return Categorical(logits=logits)
+
+    def predict(self, obs: torch.Tensor, deterministic: bool = False) -> torch.Tensor:
+        """Predict the action based on given observations.
+
+        The predicted action depends on the ``deterministic`` flag.
+
+        - If ``deterministic`` is ``True``, the predicted action is the action with highest probability.
+        - If ``deterministic`` is ``False``, the predicted action is sampled from the distribution.
+
+        Args:
+            obs (torch.Tensor): Observation from environments.
+            deterministic (bool, optional): Whether to use deterministic policy. Defaults to False.
+
+        Returns:
+            The action with highest probability if deterministic is True,
+            otherwise a sampled action from the distribution.
+        """
+        self._current_dist = self._distribution(obs=obs)
+        self._after_inference = True
+        if deterministic:
+            return torch.argmax(self._current_dist.logits, dim=0, keepdim=False)
+        return self._current_dist.sample()
+
+    def forward(self, obs: torch.Tensor) -> Distribution:
+        """Forward method.
+
+        Args:
+            obs (torch.Tensor): Observation from environments.
+
+        Returns:
+            The current distribution.
+        """
+        self._current_dist = self._distribution(obs)
+        self._after_inference = True
+        return self._current_dist
+
+    def log_prob(self, act: torch.Tensor) -> torch.Tensor:
+        """Compute the log probability of the action given the current distribution.
+
+        .. warning::
+            You must call :meth:`forward` or :meth:`predict` before calling this method.
+
+        Args:
+            act (torch.Tensor): Action from :meth:`predict` or :meth:`forward` .
+
+        Returns:
+            Log probability of the action.
+        """
+        assert self._after_inference, 'log_prob() should be called after predict() or forward()'
+        self._after_inference = False
+        return self._current_dist.log_prob(act)

--- a/omnisafe/models/base.py
+++ b/omnisafe/models/base.py
@@ -65,11 +65,15 @@ class Actor(nn.Module, ABC):
 
         if isinstance(self._obs_space, spaces.Box) and len(self._obs_space.shape) == 1:
             self._obs_dim: int = self._obs_space.shape[0]
+        elif isinstance(self._obs_space, spaces.Discrete):
+            self._obs_dim = 1
         else:
             raise NotImplementedError
 
         if isinstance(self._act_space, spaces.Box) and len(self._act_space.shape) == 1:
             self._act_dim: int = self._act_space.shape[0]
+        elif isinstance(self._act_space, spaces.Discrete):
+            self._act_dim = int(self._act_space.n)
         else:
             raise NotImplementedError
 
@@ -201,11 +205,15 @@ class Critic(nn.Module, ABC):
         self._use_obs_encoder: bool = use_obs_encoder
 
         if isinstance(self._obs_space, spaces.Box) and len(self._obs_space.shape) == 1:
-            self._obs_dim = self._obs_space.shape[0]
+            self._obs_dim: int = self._obs_space.shape[0]
+        elif isinstance(self._obs_space, spaces.Discrete):
+            self._obs_dim = 1
         else:
             raise NotImplementedError
 
         if isinstance(self._act_space, spaces.Box) and len(self._act_space.shape) == 1:
-            self._act_dim = self._act_space.shape[0]
+            self._act_dim: int = self._act_space.shape[0]
+        elif isinstance(self._act_space, spaces.Discrete):
+            self._act_dim = int(self._act_space.n)
         else:
             raise NotImplementedError

--- a/omnisafe/models/base.py
+++ b/omnisafe/models/base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+import numpy as np
 import torch
 import torch.nn as nn
 from gymnasium import spaces
@@ -62,11 +63,8 @@ class Actor(nn.Module, ABC):
         self._activation: Activation = activation
         self._hidden_sizes: list[int] = hidden_sizes
         self._after_inference: bool = False
-
-        if isinstance(self._obs_space, spaces.Box) and len(self._obs_space.shape) == 1:
-            self._obs_dim: int = self._obs_space.shape[0]
-        elif isinstance(self._obs_space, spaces.Discrete):
-            self._obs_dim = 1
+        if isinstance(self._obs_space, (spaces.Box, spaces.Discrete)):
+            self._obs_dim: int = int(np.array(self._obs_space.shape).prod())
         else:
             raise NotImplementedError
 

--- a/omnisafe/typing.py
+++ b/omnisafe/typing.py
@@ -39,7 +39,7 @@ Activation = Literal['identity', 'relu', 'sigmoid', 'softplus', 'tanh']
 AdvatageEstimator = Literal['gae', 'gae-rtg', 'vtrace', 'plain']
 InitFunction = Literal['kaiming_uniform', 'xavier_normal', 'glorot', 'xavier_uniform', 'orthogonal']
 CriticType = Literal['v', 'q']
-ActorType = Literal['gaussian_learning', 'gaussian_sac', 'mlp', 'vae', 'perturbation']
+ActorType = Literal['gaussian_learning', 'gaussian_sac', 'mlp', 'vae', 'perturbation', 'discrete']
 DEVICE_CPU = torch.device('cpu')
 
 

--- a/omnisafe/utils/config.py
+++ b/omnisafe/utils/config.py
@@ -255,7 +255,7 @@ def get_default_kwargs_yaml(algo: str, env_id: str, algo_type: str) -> Config:
     return default_kwargs
 
 
-def check_all_configs(configs: Config, algo_type: str) -> None:
+def check_all_configs(configs: Config, algo_type: str, env_type: str) -> None:
     """Check all configs.
 
     This function is used to check the configs.
@@ -263,10 +263,46 @@ def check_all_configs(configs: Config, algo_type: str) -> None:
     Args:
         configs (Config): The configs to be checked.
         algo_type (str): The algorithm type.
+        env_type (str): The environment type
     """
     __check_algo_configs(configs.algo_cfgs, algo_type)
+    __check_env_configs(configs, env_type)
     __check_parallel_and_vectorized(configs, algo_type)
     __check_logger_configs(configs.logger_cfgs)
+
+
+def __check_env_configs(configs: Config, env_type: str) -> None:
+    """Check whether configs are aligned with the type of environment.
+
+    Args:
+        configs (Config): The model configs to be checked.
+        env_type (str): The environment type.
+    """
+    if env_type == 'discrete':
+        assert (
+            configs.model_cfgs.actor_type == 'discrete'
+        ), 'Discrete environments only support discrete actor!'
+        assert configs.algo in [
+            'NaturalPG',
+            'PolicyGradient',
+            'PPO',
+            'TRPO',
+            'RCPO',
+            'PDO',
+            'PPOLag',
+            'TRPOLag',
+            'OnCRPO',
+            'P3O',
+            'IPO',
+            'CPPOPID',
+            'TRPOPID',
+            'CPO',
+            'PCPO',
+        ], f'Currently, OmniSafe does not support {configs.algo} running on discrete environments!'
+    if env_type == 'box':
+        assert (
+            configs.model_cfgs.actor_type != 'discrete'
+        ), 'Box environments do not support discrete actor!'
 
 
 def __check_parallel_and_vectorized(configs: Config, algo_type: str) -> None:

--- a/tests/simple_env.py
+++ b/tests/simple_env.py
@@ -35,6 +35,7 @@ class SimpleEnv(CMDP):
     metadata: ClassVar[dict[str, int]] = {'render_fps': 30}
     need_auto_reset_wrapper = True
     need_time_limit_wrapper = True
+    need_action_scale_wrapper: bool = False
     _num_envs = 1
     _coordinate_observation_space: OmnisafeSpace
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -14,8 +14,11 @@
 # ==============================================================================
 """Test Buffers."""
 
+from __future__ import annotations
+
+import numpy as np
 import torch
-from gymnasium.spaces import Box
+from gymnasium.spaces import Box, Discrete
 
 import helpers
 from omnisafe.common.buffer import (
@@ -27,8 +30,8 @@ from omnisafe.common.buffer import (
 
 
 @helpers.parametrize(
-    obs_space=[Box(low=-1, high=1, shape=(1,))],
-    act_space=[Box(low=-1, high=1, shape=(1,))],
+    obs_space=[Box(low=-1, high=1, shape=(1,)), Discrete(n=5)],
+    act_space=[Box(low=-1, high=1, shape=(1,)), Discrete(n=5)],
     size=[100],
     gamma=[0.9],
     lam=[0.9],
@@ -41,8 +44,8 @@ from omnisafe.common.buffer import (
     num_envs=[2],
 )
 def test_vector_onpolicy_buffer(
-    obs_space: Box,
-    act_space: Box,
+    obs_space: Box | Discrete,
+    act_space: Box | Discrete,
     size: int,
     gamma: float,
     lam: float,
@@ -82,8 +85,8 @@ def test_vector_onpolicy_buffer(
     assert vector_buffer.buffers is not [], f'vector_buffer.buffers is {vector_buffer.buffers}'
 
     # checking the store function
-    obs_dim = obs_space.shape[0]
-    act_dim = act_space.shape[0]
+    obs_dim = int(np.array(obs_space.shape).prod())
+    act_dim = int(np.array(act_space.shape).prod())
     for _ in range(size):
         obs = torch.rand((num_envs, obs_dim), dtype=torch.float32, device=device)
         act = torch.rand((num_envs, act_dim), dtype=torch.float32, device=device)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Test envs."""
 
-from gymnasium.spaces import Box
+from gymnasium.spaces import Box, Discrete
 
 import helpers
 from omnisafe.envs.core import make
@@ -150,3 +150,49 @@ def test_mujoco(num_envs, env_id) -> None:
     assert isinstance(info, dict)
 
     env.close()
+
+
+@helpers.parametrize(
+    num_envs=[1, 2],
+)
+def test_discrete(num_envs) -> None:
+    """Test envs."""
+    env_id = 'CartPole-v1'
+    env = make(env_id, num_envs=num_envs)
+
+    obs_space = env.observation_space
+    act_space = env.action_space
+
+    assert isinstance(obs_space, Box)
+    assert isinstance(act_space, Discrete)
+
+    env.set_seed(0)
+    obs, _ = env.reset()
+    if num_envs > 1:
+        assert obs.shape == (num_envs, obs_space.shape[0])
+    else:
+        assert obs.shape == (obs_space.shape[0],)
+
+    act = env.sample_action()
+
+    obs, reward, cost, terminated, truncated, info = env.step(act)
+
+    if num_envs > 1:
+        assert obs.shape == (num_envs, obs_space.shape[0])
+        assert reward.shape == (num_envs,)
+        assert cost.shape == (num_envs,)
+        assert terminated.shape == (num_envs,)
+        assert truncated.shape == (num_envs,)
+        assert isinstance(info, dict)
+    else:
+        assert obs.shape == (obs_space.shape[0],)
+        assert reward.shape == ()
+        assert cost.shape == ()
+        assert terminated.shape == ()
+        assert truncated.shape == ()
+        assert isinstance(info, dict)
+
+    env.close()
+
+
+test_discrete(num_envs=2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,11 +42,11 @@ def test_critic(
     use_obs_encoder: bool,
 ) -> None:
     """Test critic."""
-    obs_sapce = Box(low=-1.0, high=1.0, shape=(obs_dim,))
+    obs_space = Box(low=-1.0, high=1.0, shape=(obs_dim,))
     act_space = Box(low=-1.0, high=1.0, shape=(act_dim,))
 
     builder = CriticBuilder(
-        obs_space=obs_sapce,
+        obs_space=obs_space,
         act_space=act_space,
         hidden_sizes=[hidden_sizes, hidden_sizes],
         activation=activation,
@@ -81,11 +81,11 @@ def test_actor(
     deterministic: bool,
 ) -> None:
     """Test actor."""
-    obs_sapce = Box(low=-1.0, high=1.0, shape=(obs_dim,))
+    obs_space = Box(low=-1.0, high=1.0, shape=(obs_dim,))
     act_space = Box(low=-1.0, high=1.0, shape=(act_dim,))
 
     builder = ActorBuilder(
-        obs_space=obs_sapce,
+        obs_space=obs_space,
         act_space=act_space,
         hidden_sizes=[hidden_sizes, hidden_sizes],
         activation=activation,
@@ -136,7 +136,7 @@ def test_actor_critic(
     """Test actor critic."""
     obs_dim = 10
     act_dim = 5
-    obs_sapce = Box(low=-1.0, high=1.0, shape=(obs_dim,))
+    obs_space = Box(low=-1.0, high=1.0, shape=(obs_dim,))
     act_space = Box(low=-1.0, high=1.0, shape=(act_dim,))
 
     model_cfgs = Config(
@@ -150,7 +150,7 @@ def test_actor_critic(
     )
 
     ac = ActorCritic(
-        obs_space=obs_sapce,
+        obs_space=obs_space,
         act_space=act_space,
         model_cfgs=model_cfgs,
         epochs=10,
@@ -164,7 +164,7 @@ def test_actor_critic(
     ac.annealing(5)
 
     cac = ConstraintActorCritic(
-        obs_space=obs_sapce,
+        obs_space=obs_space,
         act_space=act_space,
         model_cfgs=model_cfgs,
         epochs=10,
@@ -179,25 +179,38 @@ def test_actor_critic(
     cac.annealing(5)
 
 
-@helpers.parametrize(obs_act_type=[('discrete', 'continuous'), ('continuous', 'discrete')])
-def test_raise_error(obs_act_type):
-    obs_type, act_type = obs_act_type
-
-    obs_sapce = Discrete(10) if obs_type == 'discrete' else Box(low=-1.0, high=1.0, shape=(10,))
-    act_space = Discrete(5) if act_type == 'discrete' else Box(low=-1.0, high=1.0, shape=(5,))
+@helpers.parametrize(
+    obs_dim=[10],
+    act_dim=[5],
+    hidden_sizes=[64],
+    activation=['tanh', 'relu'],
+    deterministic=[True, False],
+)
+def test_discrete_actor(
+    obs_dim: int,
+    act_dim: int,
+    hidden_sizes: int,
+    activation: Activation,
+    deterministic: bool,
+) -> None:
+    """Test actor."""
+    box_obs_space = Box(low=-1.0, high=1.0, shape=(obs_dim,))
+    # discrete_obs_space = Discrete(1)
+    act_space = Discrete(act_dim)
 
     builder = ActorBuilder(
-        obs_space=obs_sapce,
+        obs_space=box_obs_space,
         act_space=act_space,
-        hidden_sizes=[3, 3],
+        hidden_sizes=[hidden_sizes, hidden_sizes],
+        activation=activation,
     )
+    obs = torch.randn(obs_dim, dtype=torch.float32)
+    actor_discrete = builder.build_actor(actor_type='discrete')
     with pytest.raises(NotImplementedError):
-        builder.build_actor(actor_type='gaussian_learning')
+        builder.build_actor(actor_type='invalid')
 
-    builder = CriticBuilder(
-        obs_space=obs_sapce,
-        act_space=act_space,
-        hidden_sizes=[3, 3],
-    )
-    with pytest.raises(NotImplementedError):
-        builder.build_critic(critic_type='q')
+    _ = actor_discrete(obs)
+    action = actor_discrete.predict(obs, deterministic)
+    assert action.shape == torch.Size([]), f'actor output shape is {action.shape}'
+    logp = actor_discrete.log_prob(action)
+    assert logp.shape == torch.Size([]), f'actor log_prob shape is {logp.shape}'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -211,6 +211,6 @@ def test_discrete_actor(
 
     _ = actor_discrete(obs)
     action = actor_discrete.predict(obs, deterministic)
-    assert action.shape == torch.Size([]), f'actor output shape is {action.shape}'
+    assert action.shape == torch.Size([1, 1]), f'actor output shape is {action.shape}'
     logp = actor_discrete.log_prob(action)
     assert logp.shape == torch.Size([]), f'actor log_prob shape is {logp.shape}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,12 +80,17 @@ def test_custom_cfgs_to_dict():
 
 def test_config():
     """Test config"""
-    cfg = Config(a=1, b={'c': 2})
+    cfg = Config(a=1, b={'c': 2}, model_cfgs={'actor_type': 'gaussian_learning'})
     cfg.a = 2
     cfg.recurisve_update({'a': {'d': 3}, 'e': {'f': 4}})
     cfg = get_default_kwargs_yaml('PPO', 'Simple-v0', 'on-policy')
     cfg.recurisve_update({'exp_name': 'test_configs', 'env_id': 'Simple-v0', 'algo': 'PPO'})
-    check_all_configs(cfg, 'on-policy')
+    check_all_configs(cfg, 'on-policy', 'box')
+    with pytest.raises(AssertionError):
+        check_all_configs(cfg, 'off-pocliy', 'discrete')
+    cfg.recurisve_update({'model_cfgs': {'actor_type': 'discrete'}})
+    with pytest.raises(AssertionError):
+        check_all_configs(cfg, 'on-pocliy', 'box')
 
 
 def test_distributed():


### PR DESCRIPTION
# Description

This pull request is aimed at supporting environments with discrete action spaces and observation spaces. It has been implemented in the [Taxi-v3](https://gymnasium.farama.org/environments/toy_text/taxi/) and [CartPole-v1](https://gymnasium.farama.org/environments/classic_control/cart_pole/) environments in Gymnasium. Relevant documents, code checks, and standards have been updated. Currently, it supports the following on-policy algorithms:
```python
['NaturalPG', 'PolicyGradient', 'PPO', 'TRPO', 'RCPO', 'PDO', 'PPOLag', 'TRPOLag', 'OnCRPO', 'P3O', 'IPO', 'CPPOPID', 'TRPOPID', 'CPO', 'PCPO',]
```
to run in discrete environments.
The performance curve below shows the correctness of our implementation.
![algo---CartPole-v1---bd252e6d92d63ae5628feb2cb9f076c4535775919201e12bb086eb4496b3ed4f](https://github.com/PKU-Alignment/omnisafe/assets/108712610/f7b745ee-fbe1-41ab-a8e6-3de146e78646)

## Motivation and Context

resolve #273 #283

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
