### PR TITLE
Correction for the name of offline safe algorithm COptiDICE and bug of load_state_dict in normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ python train_policy.py --algo PPOLag --env-id SafetyPointGoal1-v0 --parallel 1 -
   </tr>
   <tr>
     <td>DICE Based</td>
-    <td>COptDICE</td>
+    <td>COptiDICE</td>
   </tr>
   <tr>
     <td rowspan="3">Other Formulation MDP</td>

--- a/omnisafe/common/normalizer.py
+++ b/omnisafe/common/normalizer.py
@@ -155,4 +155,4 @@ class Normalizer(nn.Module):
             The loaded normalizer.
         """
         self._first = False
-        return super().load_state_dict(state_dict, strict, assign)
+        return super().load_state_dict(state_dict, strict)


### PR DESCRIPTION
# Description
The algorithm name for COptiDICE was written incorrectly.

If I use the code part /* return super().load_state_dict(state_dict, strict) */ , the following error will generate
![image](https://github.com/PKU-Alignment/omnisafe/assets/105222256/13cd73ce-51d4-4154-8850-5f4eb9ab251c)
something about this error 
![image](https://github.com/PKU-Alignment/omnisafe/assets/105222256/bd39d333-97a7-459e-8f94-1788dda61088)

Describe your changes in detail.
change COptDICE to COptiDICE
change return super().load_state_dict(state_dict, strict, assign) to return super().load_state_dict(state_dict, strict)
## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
