### PR TITLE
docs: add missing \lambda

### DIFF
--- a/docs/source/saferl/lag.rst
+++ b/docs/source/saferl/lag.rst
@@ -253,10 +253,10 @@ Policy update
             .. attention::
                 :class: warning
 
-                In practice, we often need to manually set the initial value of as well as the learning rate.
+                In practice, we often need to manually set the initial value of :math:`\lambda` as well as the learning rate :math:`\eta_\lambda`.
                 Unfortunately, Lagrange algorithms are algorithms that **are sensitive to hyperparameter selection**.
 
-                - If the initial value of :math:`\lambda` or learning rate is chosen to be large,
+                - If the initial value of :math:`\lambda` or learning rate :math:`\eta_\lambda` is chosen to be large,
                   the agent may suffer from a low reward.
                 - Else, it may violate the constraints.
 


### PR DESCRIPTION
# Description

It seems that the `$\lambda$` is missing after `value of`.

![Snipaste_2024-01-04_15-05-24](https://github.com/xujinming01/omnisafe/assets/80799351/6ecfcc7e-87dd-44e2-9738-644189ee4144)


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
