### PR TITLE
fix: fix cuda initialization error in experiment grid

### DIFF
--- a/omnisafe/common/experiment_grid.py
+++ b/omnisafe/common/experiment_grid.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing as mp
 import os
 import string
 from concurrent.futures import ProcessPoolExecutor as Pool
@@ -440,7 +441,7 @@ class ExperimentGrid:
         announcement = f'\n{joined_var_names}\n\n{line}'
         print(announcement)
 
-        pool = Pool(max_workers=num_pool)
+        pool = Pool(max_workers=num_pool, mp_context=mp.get_context('spawn'))
         # run the variants.
         results = []
         exp_names = []


### PR DESCRIPTION
# Description

Modify the multi-process context to default `fork` to `spawn`.

## Motivation and Context

close #314 

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
