### PR TITLE
fix: remove duplicated auto reset

### DIFF
--- a/omnisafe/adapter/online_adapter.py
+++ b/omnisafe/adapter/online_adapter.py
@@ -131,7 +131,6 @@ class OnlineAdapter:
             )
         if self._env.need_auto_reset_wrapper:
             self._env = AutoReset(self._env, device=self._device)
-            self._eval_env = AutoReset(self._eval_env, device=self._device)
         if obs_normalize:
             self._env = ObsNormalize(self._env, device=self._device)
             self._eval_env = ObsNormalize(self._eval_env, device=self._device)

--- a/omnisafe/envs/mujoco_env.py
+++ b/omnisafe/envs/mujoco_env.py
@@ -145,7 +145,7 @@ class MujocoEnv(CMDP):
     @property
     def max_episode_steps(self) -> int:
         """The max steps per episode."""
-        return self._env.env.spec.max_episode_steps  # type: ignore
+        return self._env.spec.max_episode_steps  # type: ignore
 
     def reset(
         self,

--- a/omnisafe/envs/safety_gymnasium_env.py
+++ b/omnisafe/envs/safety_gymnasium_env.py
@@ -147,7 +147,7 @@ class SafetyGymnasiumEnv(CMDP):
         else:
             self.need_time_limit_wrapper = True
             self.need_auto_reset_wrapper = True
-            self._env = safety_gymnasium.make(id=env_id, autoreset=True, **kwargs)
+            self._env = safety_gymnasium.make(id=env_id, autoreset=False, **kwargs)
             assert isinstance(self._env.action_space, Box), 'Only support Box action space.'
             assert isinstance(
                 self._env.observation_space,
@@ -230,7 +230,7 @@ class SafetyGymnasiumEnv(CMDP):
     @property
     def max_episode_steps(self) -> int:
         """The max steps per episode."""
-        return self._env.env.spec.max_episode_steps
+        return self._env.spec.max_episode_steps
 
     def set_seed(self, seed: int) -> None:
         """Set the seed for the environment.


### PR DESCRIPTION
# Description

OmniSafe and [Safety Gymnasium](https://github.com/PKU-Alignment/safety-gymnasium) both provide an `AutoReset` Wrapper, which automatically calls the reset function to refresh when the current episode ends. This PR is used to fix the issue of environment information getting mixed up due to the repeated use of auto reset.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
