### PR TITLE
feat: support metadrive env

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -38,4 +38,5 @@ exclude =
     build,
     dist,
     examples,
-    tests
+    tests,
+    conftest.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
           (?x)(
             ^omnisafe/algorithms/off_policy/crabs.py$|
             ^omnisafe/common/control_barrier_function/crabs/|
-            ^omnisafe/envs/classic_control/envs_from_crabs.py$
+            ^omnisafe/envs/classic_control/envs_from_crabs.py$|
+            ^conftest.py$
           )
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
@@ -66,7 +67,8 @@ repos:
           (?x)(
             ^examples/|
             ^tests/|
-            ^docs/source/conf.py$
+            ^docs/source/conf.py$|
+            ^conftest.py$
           )
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
@@ -96,7 +98,8 @@ repos:
             ^omnisafe/common/control_barrier_function/crabs/utils.py$|
             ^omnisafe/algorithms/off_policy/crabs.py$|
             ^omnisafe/utils/isaac_gym_utils.py$|
-            ^docs/source/conf.py$
+            ^docs/source/conf.py$|
+            ^conftest.py$
           )
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0
@@ -113,5 +116,6 @@ repos:
             ^omnisafe/envs/classic_control/envs_from_crabs.py$|
             ^omnisafe/common/control_barrier_function/crabs/models.py$|
             ^omnisafe/common/control_barrier_function/crabs/optimizers.py$|
-            ^omnisafe/common/control_barrier_function/crabs/utils.py$
+            ^omnisafe/common/control_barrier_function/crabs/utils.py$|
+            ^conftest.py$
           )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+
+try:
+    from metadrive import SafeMetaDriveEnv
+
+    meta_drive_env_available = True
+except ImportError:
+    meta_drive_env_available = False
+
+
+def pytest_ignore_collect(path, config):
+    if os.path.basename(path) == 'meta_drive_env.py' and not meta_drive_env_available:
+        return True
+    return False

--- a/omnisafe/algorithms/off_policy/ddpg.py
+++ b/omnisafe/algorithms/off_policy/ddpg.py
@@ -128,6 +128,7 @@ class DDPG(BaseAlgo):
             size=self._cfgs.algo_cfgs.size,
             batch_size=self._cfgs.algo_cfgs.batch_size,
             num_envs=self._cfgs.train_cfgs.vector_env_nums,
+            penalty_coefficient=self._cfgs.algo_cfgs.get('penalty_coefficient', 0.0),
             device=self._device,
         )
 

--- a/omnisafe/common/buffer/offpolicy_buffer.py
+++ b/omnisafe/common/buffer/offpolicy_buffer.py
@@ -55,6 +55,7 @@ class OffPolicyBuffer(BaseBuffer):
         act_space: OmnisafeSpace,
         size: int,
         batch_size: int,
+        penalty_coefficient: float = 0.0,
         device: torch.device = DEVICE_CPU,
     ) -> None:
         """Initialize an instance of :class:`OffPolicyBuffer`."""
@@ -72,6 +73,7 @@ class OffPolicyBuffer(BaseBuffer):
         self._size: int = 0
         self._max_size: int = size
         self._batch_size: int = batch_size
+        self._penalty_coefficient: float = penalty_coefficient
 
         assert (
             self._max_size > self._batch_size
@@ -104,6 +106,7 @@ class OffPolicyBuffer(BaseBuffer):
         """
         for key, value in data.items():
             self.data[key][self._ptr] = value
+        self.data['reward'][self._ptr] -= self._penalty_coefficient * self.data['cost'][self._ptr]
         self._ptr = (self._ptr + 1) % self._max_size
         self._size = min(self._size + 1, self._max_size)
 

--- a/omnisafe/common/buffer/offpolicy_buffer.py
+++ b/omnisafe/common/buffer/offpolicy_buffer.py
@@ -42,6 +42,7 @@ class OffPolicyBuffer(BaseBuffer):
         act_space (OmnisafeSpace): The action space.
         size (int): The size of the buffer.
         batch_size (int): The batch size of the buffer.
+        penalty_coefficient (float, optional): The penalty coefficient. Defaults to 0.0.
         device (torch.device, optional): The device of the buffer. Defaults to
             ``torch.device('cpu')``.
 

--- a/omnisafe/common/buffer/vector_offpolicy_buffer.py
+++ b/omnisafe/common/buffer/vector_offpolicy_buffer.py
@@ -56,6 +56,7 @@ class VectorOffPolicyBuffer(OffPolicyBuffer):
         size: int,
         batch_size: int,
         num_envs: int,
+        penalty_coefficient: float = 0.0,
         device: torch.device = DEVICE_CPU,
     ) -> None:
         """Initialize an instance of :class:`VectorOffPolicyBuffer`."""
@@ -64,6 +65,7 @@ class VectorOffPolicyBuffer(OffPolicyBuffer):
         self._size: int = 0
         self._max_size: int = size
         self._batch_size: int = batch_size
+        self._penalty_coefficient: float = penalty_coefficient
         self._device: torch.device = device
         if isinstance(obs_space, Box):
             obs_buf = torch.zeros(

--- a/omnisafe/common/buffer/vector_offpolicy_buffer.py
+++ b/omnisafe/common/buffer/vector_offpolicy_buffer.py
@@ -38,6 +38,7 @@ class VectorOffPolicyBuffer(OffPolicyBuffer):
         size (int): The size of the buffer.
         batch_size (int): The batch size of the buffer.
         num_envs (int): The number of environments.
+        penalty_coefficient (float, optional): The penalty coefficient. Defaults to 0.0.
         device (torch.device, optional): The device of the buffer. Defaults to
             ``torch.device('cpu')``.
 

--- a/omnisafe/configs/off-policy/SAC.yaml
+++ b/omnisafe/configs/off-policy/SAC.yaml
@@ -42,6 +42,8 @@ defaults:
     size: 1000000
     # The size of batch
     batch_size: 256
+    # penalty coefficient
+    penalty_coef: 0.0
     # normalize reward
     reward_normalize: False
     # normalize cost
@@ -180,3 +182,47 @@ SafetyPointGoal1-v0:
     critic:
       # The learning rate of Critic network
       lr: 0.001
+
+SafeMetaDrive:
+  # training configurations
+  train_cfgs:
+    # total number of steps to train
+    total_steps: 500000
+    # number of evaluate episodes
+    eval_episodes: 0
+  # algorithm configurations
+  algo_cfgs:
+    # number of steps per sample
+    update_cycle: 100
+    # number of iterations to update the policy
+    update_iters: 200
+    # normalize reward
+    reward_normalize: True
+    # Whether to use auto alpha
+    auto_alpha: False
+    # penalty coefficient
+    penalty_coef: 1.0
+  # model configurations
+  model_cfgs:
+    # actor network configurations
+    actor:
+      # learning rate
+      lr: 0.0003
+    # critic network configurations
+    critic:
+      # learning rate
+      lr: 0.0001
+  # environment specific configurations
+  env_cfgs:
+  # safe meta drive configurations. More details refer to https://github.com/decisionforce/EGPO
+    meta_drive_config:
+      # max iterations of interactions
+      horizon: 1500
+      # whether to use random traffic
+      random_traffic: False
+      # the penalty when crash into other vehicles
+      crash_vehicle_penalty: 1.
+      # the penalty when crash into other objects
+      crash_object_penalty: 0.5
+      # the penalty when out of road
+      out_of_road_penalty: 1.

--- a/omnisafe/configs/off-policy/SACLag.yaml
+++ b/omnisafe/configs/off-policy/SACLag.yaml
@@ -288,11 +288,11 @@ SafeMetaDrive:
       out_of_road_penalty: 1.
   # lagrangian configurations
   lagrange_cfgs:
-    # Tolerance of constraint violation
-    cost_limit: 1.0
-    # Initial value of lagrangian multiplier
+    # tolerance of constraint violation
+    cost_limit: 0.0
+    # initial value of lagrangian multiplier
     lagrangian_multiplier_init: 0.01
-    # Learning rate of lagrangian multiplier
+    # learning rate of lagrangian multiplier
     lambda_lr: 0.0001
-    # Type of lagrangian optimizer
+    # type of lagrangian optimizer
     lambda_optimizer: "Adam"

--- a/omnisafe/configs/off-policy/SACLag.yaml
+++ b/omnisafe/configs/off-policy/SACLag.yaml
@@ -240,3 +240,59 @@ SafetyPointGoal1-v0:
     lambda_lr: 0.0000005
     # Type of lagrangian optimizer
     lambda_optimizer: "Adam"
+
+SafeMetaDrive:
+  # training configurations
+  train_cfgs:
+    # total number of steps to train
+    total_steps: 500000
+    # number of evaluate episodes
+    eval_episodes: 0
+  # algorithm configurations
+  algo_cfgs:
+    # number of steps per sample
+    update_cycle: 100
+    # number of iterations to update the policy
+    update_iters: 200
+    # normalize reward
+    reward_normalize: True
+    # normalize cost
+    cost_normalize: True
+    # warm up epoch
+    warmup_epochs: 10
+    # Whether to use auto alpha
+    auto_alpha: False
+  # model configurations
+  model_cfgs:
+    # actor network configurations
+    actor:
+      # learning rate
+      lr: 0.0003
+    # critic network configurations
+    critic:
+      # learning rate
+      lr: 0.0001
+  # environment specific configurations
+  env_cfgs:
+  # safe meta drive configurations. More details refer to https://github.com/decisionforce/EGPO
+    meta_drive_config:
+      # max iterations of interactions
+      horizon: 1500
+      # whether to use random traffic
+      random_traffic: False
+      # the penalty when crash into other vehicles
+      crash_vehicle_penalty: 1.
+      # the penalty when crash into other objects
+      crash_object_penalty: 0.5
+      # the penalty when out of road
+      out_of_road_penalty: 1.
+  # lagrangian configurations
+  lagrange_cfgs:
+    # Tolerance of constraint violation
+    cost_limit: 1.0
+    # Initial value of lagrangian multiplier
+    lagrangian_multiplier_init: 0.01
+    # Learning rate of lagrangian multiplier
+    lambda_lr: 0.0001
+    # Type of lagrangian optimizer
+    lambda_optimizer: "Adam"

--- a/omnisafe/configs/on-policy/CPO.yaml
+++ b/omnisafe/configs/on-policy/CPO.yaml
@@ -126,8 +126,6 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
-  # environment specific configurations
-  env_cfgs: null
 
 SafeMetaDrive:
   # training configurations
@@ -159,11 +157,13 @@ SafeMetaDrive:
   model_cfgs:
     # actor network configurations
     actor:
+      # size of hidden layers
       hidden_sizes: [256, 256]
       # learning rate
       lr: 0.00005
     # critic network configurations
     critic:
+      # size of hidden layers
       hidden_sizes: [256, 256]
       # learning rate
       lr: 0.00005

--- a/omnisafe/configs/on-policy/CPO.yaml
+++ b/omnisafe/configs/on-policy/CPO.yaml
@@ -126,3 +126,58 @@ defaults:
       activation: tanh
       # learning rate
       lr: 0.001
+  # environment specific configurations
+  env_cfgs: null
+
+SafeMetaDrive:
+  # training configurations
+  train_cfgs:
+    # total number of steps to train
+    total_steps: 500000
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 15
+  # algorithm configurations
+  algo_cfgs:
+    # batch size for each iteration
+    batch_size: 512
+    # number of steps to update the policy
+    steps_per_epoch: 3000
+    # number of iterations to update the policy
+    update_iters: 10
+    # normalize reward
+    reward_normalize: False
+    # normalize cost
+    cost_normalize: True
+    # normalize observation
+    obs_normalize: False
+    # max gradient norm
+    max_grad_norm: 20.0
+    cost_limit: 1
+  # model configurations
+  model_cfgs:
+    # actor network configurations
+    actor:
+      hidden_sizes: [256, 256]
+      # learning rate
+      lr: 0.00005
+    # critic network configurations
+    critic:
+      hidden_sizes: [256, 256]
+      # learning rate
+      lr: 0.00005
+  # environment specific configurations
+  env_cfgs:
+  # safe meta drive configurations. More details refer to https://github.com/decisionforce/EGPO
+    meta_drive_config:
+      # max iterations of interactions
+      horizon: 1500
+      # whether to use random traffic
+      random_traffic: False
+      # the penalty when crash into other vehicles
+      crash_vehicle_penalty: 1.
+      # the penalty when crash into other objects
+      crash_object_penalty: 0.5
+      # the penalty when out of road
+      out_of_road_penalty: 1.

--- a/omnisafe/configs/on-policy/PPO.yaml
+++ b/omnisafe/configs/on-policy/PPO.yaml
@@ -308,10 +308,14 @@ SafeMetaDrive:
   model_cfgs:
     # actor network configurations
     actor:
+      # hidden layer sizes
+      hidden_sizes: [256, 256]
       # learning rate
       lr: 0.00005
     # critic network configurations
     critic:
+      # hidden layer sizes
+      hidden_sizes: [256, 256]
       # learning rate
       lr: 0.00005
   # environment specific configurations

--- a/omnisafe/configs/on-policy/PPO.yaml
+++ b/omnisafe/configs/on-policy/PPO.yaml
@@ -274,3 +274,57 @@ ShadowHandOverSafeJoint:
       hidden_sizes: [1024, 1024, 512]
       # learning rate
       lr: 0.0006
+
+SafeMetaDrive:
+  # training configurations
+  train_cfgs:
+    # total number of steps to train
+    total_steps: 500000
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 15
+  # algorithm configurations
+  algo_cfgs:
+    # batch size for each iteration
+    batch_size: 256
+    # entropy coefficient
+    entropy_coef: 0.01
+    # number of steps to update the policy
+    steps_per_epoch: 3000
+    # number of iterations to update the policy
+    update_iters: 40
+    # normalize reward
+    reward_normalize: False
+    # normalize cost
+    cost_normalize: True
+    # normalize observation
+    obs_normalize: False
+    # max gradient norm
+    max_grad_norm: 0.05
+    # penalty coefficient
+    penalty_coef: 1.0
+  # model configurations
+  model_cfgs:
+    # actor network configurations
+    actor:
+      # learning rate
+      lr: 0.00005
+    # critic network configurations
+    critic:
+      # learning rate
+      lr: 0.00005
+  # environment specific configurations
+  env_cfgs:
+  # safe meta drive configurations. More details refer to https://github.com/decisionforce/EGPO
+    meta_drive_config:
+      # max iterations of interactions
+      horizon: 1500
+      # whether to use random traffic
+      random_traffic: False
+      # the penalty when crash into other vehicles
+      crash_vehicle_penalty: 1.
+      # the penalty when crash into other objects
+      crash_object_penalty: 0.5
+      # the penalty when out of road
+      out_of_road_penalty: 1.

--- a/omnisafe/configs/on-policy/PPOLag.yaml
+++ b/omnisafe/configs/on-policy/PPOLag.yaml
@@ -241,7 +241,7 @@ ShadowHandCatchOver2UnderarmSafeJoint:
       hidden_sizes: [1024, 1024, 512]
       # learning rate
       lr: 0.0006
-      
+
 SafeMetaDrive:
   # training configurations
   train_cfgs:

--- a/omnisafe/configs/on-policy/PPOLag.yaml
+++ b/omnisafe/configs/on-policy/PPOLag.yaml
@@ -241,40 +241,69 @@ ShadowHandCatchOver2UnderarmSafeJoint:
       hidden_sizes: [1024, 1024, 512]
       # learning rate
       lr: 0.0006
-
-ShadowHandOverSafeJoint:
+      
+SafeMetaDrive:
   # training configurations
   train_cfgs:
-    # number of vectorized environments
-    vector_env_nums: 256
     # total number of steps to train
-    total_steps: 100000000
+    total_steps: 500000
+  # logger configurations
+  logger_cfgs:
+    # save model frequency
+    save_model_freq: 15
   # algorithm configurations
   algo_cfgs:
-    # number of steps to update the policy
-    steps_per_epoch: 38400
-    # number of iterations to update the policy
-    update_iters: 8
     # batch size for each iteration
-    batch_size: 8192
-    # target kl divergence
-    target_kl: 0.016
-    # max gradient norm
-    max_grad_norm: 1.0
-    # use critic norm
-    use_critic_norm: False
-    # reward discount factor
-    gamma: 0.96
+    batch_size: 256
+    # entropy coefficient
+    entropy_coef: 0.01
+    # number of steps to update the policy
+    steps_per_epoch: 3000
+    # number of iterations to update the policy
+    update_iters: 40
+    # normalize reward
+    reward_normalize: False
+    # normalize cost
+    cost_normalize: True
     # normalize observation
     obs_normalize: False
+    # max gradient norm
+    max_grad_norm: 0.05
   # model configurations
   model_cfgs:
     # actor network configurations
     actor:
       # hidden layer sizes
-      hidden_sizes: [1024, 1024, 512]
+      hidden_sizes: [256, 256]
+      # learning rate
+      lr: 0.00005
+    # critic network configurations
     critic:
       # hidden layer sizes
-      hidden_sizes: [1024, 1024, 512]
+      hidden_sizes: [256, 256]
       # learning rate
-      lr: 0.0006
+      lr: 0.00005
+  # environment specific configurations
+  env_cfgs:
+  # safe meta drive configurations. More details refer to https://github.com/decisionforce/EGPO
+    meta_drive_config:
+      # max iterations of interactions
+      horizon: 1500
+      # whether to use random traffic
+      random_traffic: False
+      # the penalty when crash into other vehicles
+      crash_vehicle_penalty: 1.
+      # the penalty when crash into other objects
+      crash_object_penalty: 0.5
+      # the penalty when out of road
+      out_of_road_penalty: 1.
+  # lagrangian configurations
+  lagrange_cfgs:
+    # Tolerance of constraint violation
+    cost_limit: 0.0
+    # Initial value of lagrangian multiplier
+    lagrangian_multiplier_init: 0.01
+    # Learning rate of lagrangian multiplier
+    lambda_lr: 0.01
+    # Type of lagrangian optimizer
+    lambda_optimizer: "Adam"

--- a/omnisafe/configs/on-policy/PPOLag.yaml
+++ b/omnisafe/configs/on-policy/PPOLag.yaml
@@ -154,6 +154,10 @@ ShadowHandCatchOver2UnderarmSafeFinger:
     use_critic_norm: False
     # reward discount factor
     gamma: 0.96
+    # normalize reward
+    reward_normalize: False
+    # normalize cost
+    cost_normalize: False
     # normalize observation
     obs_normalize: False
   # model configurations
@@ -206,6 +210,47 @@ ShadowHandOverSafeFinger:
       lr: 0.0006
 
 ShadowHandCatchOver2UnderarmSafeJoint:
+  # training configurations
+  train_cfgs:
+    # number of vectorized environments
+    vector_env_nums: 256
+    # total number of steps to train
+    total_steps: 100000000
+  # algorithm configurations
+  algo_cfgs:
+    # number of steps to update the policy
+    steps_per_epoch: 38400
+    # number of iterations to update the policy
+    update_iters: 8
+    # batch size for each iteration
+    batch_size: 8192
+    # target kl divergence
+    target_kl: 0.016
+    # max gradient norm
+    max_grad_norm: 1.0
+    # use critic norm
+    use_critic_norm: False
+    # reward discount factor
+    gamma: 0.96
+    # normalize reward
+    reward_normalize: False
+    # normalize cost
+    cost_normalize: False
+    # normalize observation
+    obs_normalize: False
+  # model configurations
+  model_cfgs:
+    # actor network configurations
+    actor:
+      # hidden layer sizes
+      hidden_sizes: [1024, 1024, 512]
+    critic:
+      # hidden layer sizes
+      hidden_sizes: [1024, 1024, 512]
+      # learning rate
+      lr: 0.0006
+
+ShadowHandOverSafeJoint:
   # training configurations
   train_cfgs:
     # number of vectorized environments

--- a/omnisafe/envs/__init__.py
+++ b/omnisafe/envs/__init__.py
@@ -20,11 +20,8 @@ from omnisafe.envs import classic_control
 from omnisafe.envs.core import CMDP, env_register, make, support_envs
 from omnisafe.envs.crabs_env import CRABSEnv
 from omnisafe.envs.custom_env import CustomEnv
+from omnisafe.envs.meta_drive_env import SafetyMetaDriveEnv
 from omnisafe.envs.mujoco_env import MujocoEnv
 from omnisafe.envs.safety_gymnasium_env import SafetyGymnasiumEnv
 from omnisafe.envs.safety_gymnasium_modelbased import SafetyGymnasiumModelBased
 from omnisafe.envs.safety_isaac_gym_env import SafetyIsaacGymEnv
-
-
-with suppress(ImportError):
-    from omnisafe.envs.meta_drive_env import SafetyMetaDriveEnv

--- a/omnisafe/envs/__init__.py
+++ b/omnisafe/envs/__init__.py
@@ -24,3 +24,7 @@ from omnisafe.envs.mujoco_env import MujocoEnv
 from omnisafe.envs.safety_gymnasium_env import SafetyGymnasiumEnv
 from omnisafe.envs.safety_gymnasium_modelbased import SafetyGymnasiumModelBased
 from omnisafe.envs.safety_isaac_gym_env import SafetyIsaacGymEnv
+
+
+with suppress(ImportError):
+    from omnisafe.envs.meta_drive_env import SafetyMetaDriveEnv

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -84,7 +84,7 @@ class SafetyMetaDriveEnv(CMDP):
             self._env = SafeMetaDriveEnv(config=kwargs.get('meta_drive_config'))
         else:
             raise ImportError(
-                'Please install MetaDrive to use Safe SafeMetaDrive!\
+                'Please install MetaDrive to use SafeMetaDrive!\
                 \nInstall from source: https://github.com/metadriverse/metadrive.\
                 \nInstall from PyPI: `pip install metadrive`.',
             )

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -75,7 +75,7 @@ class SafetyMetaDriveEnv(CMDP):
         device: torch.device = DEVICE_CPU,
         **kwargs: Any,  # pylint: disable=unused-argument
     ) -> None:
-        """Initialize an instance of :class:`SafetyGymnasiumEnv`."""
+        """Initialize an instance of :class:`SafetyMetaDriveEnv`."""
         super().__init__(env_id)
         self._num_envs = num_envs
         self._device = torch.device(device)
@@ -83,7 +83,11 @@ class SafetyMetaDriveEnv(CMDP):
         if META_DRIVE_AVAILABLE:
             self._env = SafeMetaDriveEnv(config=kwargs.get('meta_drive_config'))
         else:
-            raise ImportError('Please install MetaDrive to use Safe SafeMetaDrive!')
+            raise ImportError(
+                'Please install MetaDrive to use Safe SafeMetaDrive!\
+                \nInstall from source: https://github.com/metadriverse/metadrive.\
+                \nInstall from PyPI: `pip install metadrive`.',
+            )
         self._num_scenarios = self._env.config['num_scenarios']
 
         self._env.logger.setLevel(logging.FATAL)

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -1,0 +1,185 @@
+# Copyright 2023 OmniSafe Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Environments interface of SafeMetaDrive."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+import numpy as np
+import torch
+from metadrive import SafeMetaDriveEnv
+
+from omnisafe.common.logger import Logger
+from omnisafe.envs.core import CMDP, env_register
+from omnisafe.typing import DEVICE_CPU
+
+
+@env_register
+class SafetyMetaDriveEnv(CMDP):
+    """SafeMetaDrive Environment.
+
+    More information about MetaDrive environment is provided in https://github.com/metadriverse/metadrive.
+
+    Args:
+        env_id (str): Environment id.
+        num_envs (int, optional): Number of environments. Defaults to 1.
+        device (torch.device, optional): Device to store the data. Defaults to
+            ``torch.device('cpu')``.
+
+    Keyword Args:
+        render_mode (str, optional): The render mode ranges from 'human' to 'rgb_array' and
+            'rgb_array_list'. Defaults to 'rgb_array'.
+        camera_name (str, optional): The camera name.
+        camera_id (int, optional): The camera id.
+        width (int, optional): The width of the rendered image. Defaults to 256.
+        height (int, optional): The height of the rendered image. Defaults to 256.
+
+    Attributes:
+        need_auto_reset_wrapper (bool): Whether to use auto reset wrapper.
+        need_time_limit_wrapper (bool): Whether to use time limit wrapper.
+    """
+
+    need_auto_reset_wrapper: bool = True
+    need_time_limit_wrapper: bool = False
+    env_spec_log: dict[str, Any]
+
+    _support_envs: ClassVar[list[str]] = [
+        'SafeMetaDrive',
+    ]
+
+    def __init__(
+        self,
+        env_id: str,
+        num_envs: int = 1,
+        device: torch.device = DEVICE_CPU,
+        **kwargs: Any,  # pylint: disable=unused-argument
+    ) -> None:
+        """Initialize an instance of :class:`SafetyGymnasiumEnv`."""
+        super().__init__(env_id)
+        self._num_envs = num_envs
+        self._device = torch.device(device)
+
+        self._env = SafeMetaDriveEnv(config=kwargs.get('meta_drive_config'))
+
+        self._num_scenarios = self._env.config['num_scenarios']
+
+        self._env.logger.setLevel(logging.FATAL)
+        self._action_space = self._env.action_space
+        self._observation_space = self._env.observation_space
+        self._metadata = self._env.metadata
+        self.env_spec_log = {'Env/Success_rate': []}
+
+    def step(
+        self,
+        action: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        dict[str, Any],
+    ]:
+        """Step the environment.
+
+        .. note::
+            OmniSafe uses auto reset wrapper to reset the environment when the episode is
+            terminated. So the ``obs`` will be the first observation of the next episode. And the
+            true ``final_observation`` in ``info`` will be stored in the ``final_observation`` key
+            of ``info``.
+
+        Args:
+            action (torch.Tensor): Action to take.
+
+        Returns:
+            observation: The agent's observation of the current environment.
+            reward: The amount of reward returned after previous action.
+            cost: The amount of cost returned after previous action.
+            terminated: Whether the episode has ended.
+            truncated: Whether the episode has been truncated due to a time limit.
+            info: Some information logged by the environment.
+        """
+        obs, reward, terminated, truncated, info = self._env.step(
+            action.detach().cpu().numpy(),
+        )
+        cost = info['cost']
+        obs, reward, cost, terminated, truncated = (
+            torch.as_tensor(x, dtype=torch.float32, device=self._device)
+            for x in (obs, reward, cost, terminated, truncated)
+        )
+        if 'final_observation' in info:
+            info['final_observation'] = np.array(
+                [
+                    array if array is not None else np.zeros(obs.shape[-1])
+                    for array in info['final_observation']
+                ],
+            )
+            info['final_observation'] = torch.as_tensor(
+                info['final_observation'],
+                dtype=torch.float32,
+                device=self._device,
+            )
+
+        # for meta drive environment, log the success rate when terminated
+        if terminated or truncated:
+            self.env_spec_log['Env/Success_rate'].append(int(info['arrive_dest']))
+
+        return obs, reward, cost, terminated, truncated, info
+
+    def spec_log(self, logger: Logger) -> None:
+        """Log the success rate into the logger."""
+        logger.store({'Env/Success_rate': np.mean(self.env_spec_log['Env/Success_rate'])})
+        self.env_spec_log['Env/Success_rate'] = []
+
+    def reset(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Reset the environment.
+
+        Args:
+            seed (int or None, optional): Seed to reset the environment.
+                Defaults to None.
+
+        Returns:
+            observation: Agent's observation of the current environment.
+            info: Some information logged by the environment.
+        """
+        obs, info = self._env.reset(seed=seed)
+        return torch.as_tensor(obs, dtype=torch.float32, device=self._device), info
+
+    def set_seed(self, seed: int) -> None:
+        """Set the seed for the environment.
+
+        Args:
+            seed (int): Seed to set.
+        """
+        self.reset()
+
+    def render(self) -> Any:
+        """Compute the render frames as specified by :attr:`render_mode` during the initialization of the environment.
+
+        Returns:
+            The render frames: we recommend to use `np.ndarray`
+                which could construct video by moviepy.
+        """
+        return self._env.render()
+
+    def close(self) -> None:
+        """Close the environment."""
+        self._env.close()

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -21,11 +21,17 @@ from typing import Any, ClassVar
 
 import numpy as np
 import torch
-from metadrive import SafeMetaDriveEnv  # pylint: disable=import-error
 
 from omnisafe.common.logger import Logger
 from omnisafe.envs.core import CMDP, env_register
 from omnisafe.typing import DEVICE_CPU
+
+
+META_DRIVE_AVAILABLE = True
+try:
+    from metadrive import SafeMetaDriveEnv
+except ImportError:
+    META_DRIVE_AVAILABLE = False
 
 
 @env_register
@@ -73,8 +79,10 @@ class SafetyMetaDriveEnv(CMDP):
         self._num_envs = num_envs
         self._device = torch.device(device)
 
-        self._env = SafeMetaDriveEnv(config=kwargs.get('meta_drive_config'))
-
+        if META_DRIVE_AVAILABLE:
+            self._env = SafeMetaDriveEnv(config=kwargs.get('meta_drive_config'))
+        else:
+            raise ImportError('Please install MetaDrive to use Safe SafeMetaDrive!')
         self._num_scenarios = self._env.config['num_scenarios']
 
         self._env.logger.setLevel(logging.FATAL)

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -39,6 +39,7 @@ class SafetyMetaDriveEnv(CMDP):
     """SafeMetaDrive Environment.
 
     More information about MetaDrive environment is provided in https://github.com/metadriverse/metadrive.
+    For the details of environment configuration, please refer to https://github.com/decisionforce/EGPO.
 
     Args:
         env_id (str): Environment id.
@@ -47,12 +48,12 @@ class SafetyMetaDriveEnv(CMDP):
             ``torch.device('cpu')``.
 
     Keyword Args:
-        render_mode (str, optional): The render mode ranges from 'human' to 'rgb_array' and
-            'rgb_array_list'. Defaults to 'rgb_array'.
-        camera_name (str, optional): The camera name.
-        camera_id (int, optional): The camera id.
-        width (int, optional): The width of the rendered image. Defaults to 256.
-        height (int, optional): The height of the rendered image. Defaults to 256.
+        meta_drive_config (dict, optional): MetaDrive configuration, containing following keys:
+            - ``horizon``: Max iterations of interactions.
+            - ``random_traffic``: Whether to use random traffic.
+            - ``crash_vehicle_penalty``: The penalty when crash into other vehicles.
+            - ``crash_object_penalty``: The penalty when crash into other objects.
+            - ``out_of_road_penalty``: The penalty when out of road.
 
     Attributes:
         need_auto_reset_wrapper (bool): Whether to use auto reset wrapper.

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -21,7 +21,7 @@ from typing import Any, ClassVar
 
 import numpy as np
 import torch
-from metadrive import SafeMetaDriveEnv
+from metadrive import SafeMetaDriveEnv  # pylint: disable=import-error
 
 from omnisafe.common.logger import Logger
 from omnisafe.envs.core import CMDP, env_register

--- a/omnisafe/envs/meta_drive_env.py
+++ b/omnisafe/envs/meta_drive_env.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OmniSafe Team. All Rights Reserved.
+# Copyright 2024 OmniSafe Team. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnisafe/envs/safety_isaac_gym_env.py
+++ b/omnisafe/envs/safety_isaac_gym_env.py
@@ -73,7 +73,10 @@ class SafetyIsaacGymEnv(CMDP):
         if ISAAC_GYM_AVAILABLE:
             self._env = make_isaac_gym_env(env_id=env_id, device=device, num_envs=num_envs)
         else:
-            raise ImportError('Please install Isaac Gym to use Safe Isaac Gym!')
+            raise ImportError(
+                'Please install Isaac Gym to use Safe Isaac Gym!\
+                \nMore details please refer to https://github.com/NVIDIA-Omniverse/IsaacGymEnvs.',
+            )
         self._action_space = self._env.action_space
         self._observation_space = self._env.observation_space
         self.need_evaluation = False

--- a/omnisafe/evaluator.py
+++ b/omnisafe/evaluator.py
@@ -144,6 +144,8 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes
             raise FileNotFoundError('The model is not found in the save directory.') from error
 
         # load the environment
+        if env_kwargs['env_id'] == 'SafeMetaDrive':
+            env_kwargs['meta_drive_config'].update({'num_scenarios': 1})
         self._env = make(**env_kwargs)
 
         observation_space = self._env.observation_space

--- a/omnisafe/utils/config.py
+++ b/omnisafe/utils/config.py
@@ -147,6 +147,13 @@ class Config(dict):
         """Set attribute."""
         self[name] = value
 
+    def get(self, name: str, default: Any = None) -> Any:
+        """Get attribute."""
+        try:
+            return self[name]
+        except KeyError:
+            return default
+
     def todict(self) -> dict[str, Any]:
         """Convert Config to dictionary.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,11 @@ typing-modules = ["omnisafe.typing"]
     "S",     # flake8-bandit
     "BLE",   # flake8-blind-except
 ]
+"conftest.py" = [
+    "F401",   # unused-import
+    "ANN201",     # missing-return-type-undocumented-public-function
+    "ANN001",   # missing-type-function-argument
+]
 
 "omnisafe/algorithms/off_policy/crabs.py" = [
     "F401",   # unused-import

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -12,6 +12,7 @@ omit =
     ../omnisafe/envs/custom_env.py
     ../omnisafe/envs/safety_isaac_gym_env.py
     ../omnisafe/utils/isaac_gym_utils.py
+    ../omnisafe/envs/meta_drive_env.py
 
 [report]
 exclude_lines =


### PR DESCRIPTION
# Description

**This PR is already complete in terms of implementation accuracy. We will merge it shortly after improving the code style and documentation.**

This PR supports `SafeMetaDrive` from [MetaDrive](https://github.com/metadriverse/metadrive)[1].

[1]: [Metadrive: Composing diverse driving scenarios for generalizable reinforcement learning](https://arxiv.org/pdf/2109.12674.pdf)

Autonomous driving is an important application of reinforcement learning algorithms, and safety is particularly crucial. Safety constraints for autonomous driving tasks are an important research direction in the SafeRL field. We have implemented the embedding of SafeMetaDrive based on our customized environment interface (more details in #310 ) and presented the SafeRL baseline algorithms involved in the MetaDrive paper as follows, hoping to inspire research on related algorithms.

<img width="938" alt="image" src="https://github.com/PKU-Alignment/omnisafe/assets/108712610/ab80212e-45ab-465f-9b60-6a39bb4301aa">


## Motivation and Context

Related issues can be found at #262 

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
