### PR TITLE
Enabled PolicyStd logging for gaussian_sac

### DIFF
--- a/omnisafe/algorithms/on_policy/base/policy_gradient.py
+++ b/omnisafe/algorithms/on_policy/base/policy_gradient.py
@@ -207,7 +207,7 @@ class PolicyGradient(BaseAlgo):
         self._logger.register_key('Train/StopIter')
         self._logger.register_key('Train/PolicyRatio', min_and_max=True)
         self._logger.register_key('Train/LR')
-        if self._cfgs.model_cfgs.actor_type == 'gaussian_learning':
+        if self._cfgs.model_cfgs.actor_type in ['gaussian_learning', 'gaussian_sac']:
             self._logger.register_key('Train/PolicyStd')
 
         self._logger.register_key('TotalEnvSteps')


### PR DESCRIPTION
# Description

Small change, we now check if the actor_type is either 'gaussian_learning' or 'gaussian_sac' when deciding on logging Train/PolicyStd.

## Motivation and Context

When I tried to run CPO with 'gaussian_sac' as the underlying actor_type, the following assertion triggered:

> AssertionError: Key Train/PolicyStd has not been registered

Upon investigation, I noticed that the abovementioned key gets added to the logger only if the actor_type is 'gaussian_learning'.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
