### PR TITLE
fix(saute): coerce tensors to correct device in SauteAdapter

### DIFF
--- a/omnisafe/adapter/saute_adapter.py
+++ b/omnisafe/adapter/saute_adapter.py
@@ -128,6 +128,7 @@ class SauteAdapter(OnPolicyAdapter):
             info: Some information logged by the environment.
         """
         obs, info = self._env.reset(seed=seed, options=options)
+        obs = obs.to(self._device)
         self._safety_obs = torch.ones(self._env.num_envs, 1).to(self._device)
         obs = self._augment_obs(obs)
         return obs, info
@@ -161,6 +162,11 @@ class SauteAdapter(OnPolicyAdapter):
             info: Some information logged by the environment.
         """
         next_obs, reward, cost, terminated, truncated, info = self._env.step(action)
+        next_obs = next_obs.to(self._device)
+        reward = reward.to(self._device)
+        cost = cost.to(self._device)
+        terminated = terminated.to(self._device)
+        truncated = truncated.to(self._device)
         info['original_reward'] = reward
 
         self._safety_step(cost)
@@ -214,6 +220,7 @@ class SauteAdapter(OnPolicyAdapter):
         Returns:
             The augmented observation.
         """
+        obs = obs.to(self._device)
         return torch.cat([obs, self._safety_obs], dim=-1)
 
     def _log_value(


### PR DESCRIPTION
Hit a device mismatch crash running PPOSaute on GPU with a custom env that returns cpu tensors. `_safety_obs` is on cuda but env outputs stay on cpu, so the in-place ops in          
  `_safety_step` fail immediately with `RuntimeError: Expected all tensors to be on the same device`.
                                                                                                                                                                                        
  Fix coerces all env outputs to `self._device` at the top of `step()` and `reset()`, plus a guard in `_augment_obs` for `final_observation`. No-op if everything is already on the   
  right device.

  ## Motivation and Context

  Affects any custom env that doesn't move its outputs to the training device — pretty common outside of mujoco/safety-gym. Crashes on the very first step.

  - [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/omnisafe/issues) for new features and bug fixes)

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds core functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation (update in the documentation)

  ## Checklist

  - [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
  - [ ] I have updated the documentation accordingly.
  - [x] I have reformatted the code using `make format`. (**required**)
  - [x] I have checked the code using `make lint`. (**required**)
  - [ ] I have ensured `make test` pass. (**required**)
