### PR TITLE
fix pid_lagrange math

### DIFF
--- a/omnisafe/common/pid_lagrange.py
+++ b/omnisafe/common/pid_lagrange.py
@@ -49,10 +49,6 @@ class PIDLagrangian(abc.ABC):  # noqa: B024
         - Title: Responsive Safety in Reinforcement Learning by PID Lagrangian Methods
         - Authors: Adam Stooke, Joshua Achiam, Pieter Abbeel.
         - URL: `PID Lagrange <https://arxiv.org/abs/2007.03964>`_
-        
-        - Title: PID Lagrangian
-        - Authors: Matthew Landers.
-        - URL: `Blog post <mattlanders.net/pid-lagrangian>`_
     """
 
     # pylint: disable-next=too-many-arguments

--- a/omnisafe/common/pid_lagrange.py
+++ b/omnisafe/common/pid_lagrange.py
@@ -49,6 +49,10 @@ class PIDLagrangian(abc.ABC):  # noqa: B024
         - Title: Responsive Safety in Reinforcement Learning by PID Lagrangian Methods
         - Authors: Adam Stooke, Joshua Achiam, Pieter Abbeel.
         - URL: `PID Lagrange <https://arxiv.org/abs/2007.03964>`_
+        
+        - Title: PID Lagrangian
+        - Authors: Matthew Landers.
+        - URL: `Blog post <mattlanders.net/pid-lagrangian>`_
     """
 
     # pylint: disable-next=too-many-arguments
@@ -96,7 +100,7 @@ class PIDLagrangian(abc.ABC):  # noqa: B024
 
         .. math::
 
-            \lambda_{t+1} = \lambda_t + (K_p e_p + K_i \int e_p dt + K_d \frac{d e_p}{d t}) \eta
+            \lambda_{t+1} = \max(0,K_p e_p + K_i \int e_p dt + K_d \frac{d e_p}{d t})
 
         where :math:`e_p` is the error between the current episode cost and the cost limit,
         :math:`K_p`, :math:`K_i`, :math:`K_d` are the PID parameters, and :math:`\eta` is the


### PR DESCRIPTION
# Description

The docstring for `PIDLagrangian.pid_update` states the update rule as:

$\lambda_{t+1} = \lambda_t + (K_p e_p + K_i \int e_p dt + K_d \frac{d e_p}{d t}) \eta$

However, this does not match the actual implementation: there is no learning rate $\eta$ and the update is not incremental ($\lambda_{t+1} = \lambda_t + \dots$). 

I suggest to replace the docstring formula with the following:
$\lambda_{t+1} = \max(0,K_p e_p + K_i \int e_p dt + K_d \frac{d e_p}{d t})$

## Motivation and Context

- [x] I have raised an issue to propose this change ( issue #391 )

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/omnisafe/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
